### PR TITLE
add cross domain support for web-fonts

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -137,6 +137,9 @@ http {
   # Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.
   #ssl_certificate      /etc/nginx/default_ssl.crt;
   #ssl_certificate_key  /etc/nginx/default_ssl.key;
+  
+  #cross domain control for web-fonts
+  add_header Access-Control-Allow-Origin  *;
 
   include sites-enabled/*;
 }


### PR DESCRIPTION
Firefox and IE 9+ will not display web fonts because of cross domain issue
