### PR TITLE
Support *.cur files

### DIFF
--- a/conf/expires.conf
+++ b/conf/expires.conf
@@ -21,7 +21,7 @@ location ~* \.(?:rss|atom)$ {
 }
 
 # Media: images, icons, video, audio, HTC
-location ~* \.(?:jpg|jpeg|gif|png|ico|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
   expires 1M;
   access_log off;
   add_header Cache-Control "public";

--- a/mime.types
+++ b/mime.types
@@ -16,7 +16,7 @@ types {
   image/tiff                            tif tiff;
   image/vnd.wap.wbmp                    wbmp;
   image/webp                            webp;
-  image/x-icon                          ico;
+  image/x-icon                          ico cur;
   image/x-jng                           jng;
 
 # JavaScript


### PR DESCRIPTION
I have noticed lack of support for *.cur files, which there are used to custom cursors ([url() value for cursor property](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor/url?redirectlocale=en-US&redirectslug=CSS%2Fcursor%2Furl)). As I know most modern browsers accept other extension for cursors (e.g. png and gif), but old IE6 recognizes only curs.
