### PR TITLE
Remove font.css related rules

### DIFF
--- a/conf/cross-domain-fonts.conf
+++ b/conf/cross-domain-fonts.conf
@@ -1,5 +1,5 @@
 # Cross domain webfont access
-location ~* \.(?:ttf|ttc|otf|eot|woff|font.css)$ {
+location ~* \.(?:ttf|ttc|otf|eot|woff)$ {
     add_header "Access-Control-Allow-Origin" "*";
 
     # Also, set cache rules for webfonts.

--- a/conf/expires.conf
+++ b/conf/expires.conf
@@ -36,7 +36,7 @@ location ~* \.(?:css|js)$ {
 
 # WebFonts
 # If you are NOT using cross-domain-fonts.conf, uncomment the following directive
-# location ~* \.(?:ttf|ttc|otf|eot|woff|font.css)$ {
+# location ~* \.(?:ttf|ttc|otf|eot|woff)$ {
 #  expires 1M;
 #  access_log off;
 #  add_header Cache-Control "public";


### PR DESCRIPTION
> a proposed convention for webfont definitions datauri'd in css.
> 
> it was silly. we dont' need it
- @paulirish 
