### PR TITLE
Add application/x-javascript to nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -97,6 +97,7 @@ http {
   # Compress all output labeled with one of the following MIME-types.
   gzip_types
     application/atom+xml
+    application/x-javascript
     application/javascript
     application/json
     application/rss+xml


### PR DESCRIPTION
Some instances of Nginx server JS with the mime-type `application/x-javascript` and thus the `nginx.conf` server needs to be told to watch for it.

For whatever reason, on my server (out of the box Nginx installed on a fresh CentOS), my JS is coming through with `application/x-javascript`, so unless I add that to the `nginx.conf`, my JavaScript doesn't get gzipped (which is sorta of a big deal when my site's mostly JavaScript!).
