### PR TITLE
Typo foorbar -> foobar

### DIFF
--- a/sites-available/README.md
+++ b/sites-available/README.md
@@ -7,6 +7,6 @@ It'd be a good thing if you keep your hosts indexed by domain name, eg:
 ```
 example.com (handles traffic from both www.example.com and example.com)
 foobar.com (as above)
-test.foobar.com (handles traffic from both www.test.foorbar.com and test.foobar.com)
+test.foobar.com (handles traffic from both www.test.foobar.com and test.foobar.com)
 ```
 


### PR DESCRIPTION
Minor typo in the sites-available/README.md

Changed foorbar to foobar
