### PR TITLE
simple proxying for websockets

### DIFF
--- a/conf/proxy-websockets.conf
+++ b/conf/proxy-websockets.conf
@@ -1,0 +1,7 @@
+# Simple proxying for websockets
+
+# This file should be required within a `location` scope
+
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";


### PR DESCRIPTION
I recently searched why all my websockets were getting `502` when my application was behind **nginx**.
This is how to enable proxying of websockets when hte client is asking a `protocol upgrade`; might be useful for some people.
