### PR TITLE
Updating the configuration for cross-domain

### DIFF
--- a/h5bp/cross-domain-ajax.conf
+++ b/h5bp/cross-domain-ajax.conf
@@ -1,2 +1,41 @@
-# Cross domain AJAX requests
-add_header "Access-Control-Allow-Origin" "*";
+# Enable cross-origin AJAX requests.
+# http://code.google.com/p/html5security/wiki/CrossOriginRequestSecurity
+# http://enable-cors.org/
+# https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS
+
+# *Security* 
+# Do not use '*' blindly, as this will open up all of your connections to other websites.
+#    add_header "Access-Control-Allow-Origin" "*";
+
+# Allow-Origin based on file-type
+# Images
+location ~* \.(cur|gif|ico|jpe?g|png|svgz?|webp)$ {
+  add_header 'Access-Control-Allow-Origin' "*";
+}
+# Fonts
+# include h5bp/cross-domain-fonts.conf
+
+# Allow-Origin based on [sub]domain
+# @example
+#    // allow a subdomian to call to this domain (assuming this conf is for example.com)
+#    add_header "Access-Control-Allow-Origin" "subdomain.example.com";
+# OR
+#    add_header "Access-Control-Allow-Origin" "*.example.com";
+#
+# Whitelisting domains
+# The cliffnote version of http://enable-cors.org/server_nginx.html
+# Allowing CORS requests from specific site
+#  scheme    : http or https
+#  authority : any authority ending in ".othersite.com"
+#  port      : nothing, or :
+#
+# To block per requesting site, wrap your code with an IF
+# if ($http_origin ~* (https?://.*\.othersite\.com(:[0-9]+)?)) { 
+#   Tells the browser this origin may make cross-origin requests
+#   (Here, we echo the requesting origin, which matched the whitelist.)
+#   add_header 'Access-Control-Allow-Origin' "$http_origin";
+#   Tells the browser it may show the response, when XmlHttpRequest.withCredentials=true.
+#   add_header 'Access-Control-Allow-Credentials' 'true';
+#   Tell the browser which response headers the JS can see, besides the "simple response headers"
+#   add_header 'Access-Control-Expose-Headers' 'myresponseheader';
+# }


### PR DESCRIPTION
The biggest issue that's here is that \* is being used which will allow any domain to use XHR connections to your domain. This opens up many security issues as it breaks the same-domain model built into the browser. It's suggested that users instead whitelist domains they wish to give connections to.
