### PR TITLE
Renamed h5bp.conf to basic.conf README

### DIFF
--- a/h5bp/README.md
+++ b/h5bp/README.md
@@ -3,5 +3,5 @@ Component-config files
 
 Each of these files is intended to be included in a server block. Not all of
 the files here are used - they are available to be included as required. The
-`h5bp.conf` file includes the rules which are recommended to always be
+`basic.conf` file includes the rules which are recommended to always be
 defined.


### PR DESCRIPTION
Updated with correct filename.
