### PR TITLE
Fix broken documentation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ accessible, if needed, even cross-domain.
 
 ## Documentation
 
-The [documentation](/h5bp/server-configs-nginx/blob/master/doc/TOC.md) is bundled with
+The [documentation table of contents](doc/TOC.md) is bundled with
 the project, which makes it readily available for offline reading and provides a
 useful starting point for any documentation you want to write about your project.
 


### PR DESCRIPTION
The documentation link in the README is broken. It can be fixed either by changing "blob" to "tree", or by linking to the table of contents. This fix opts for the latter.
