### PR TITLE
Fix charset_types as mime.types is updated

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,9 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
+  # Update charset_types due to updated mime.types
+  charset_types text/html text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml text/css application/javascript application/json
+
   # Format to use in log files
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Moved from h5bp/server-configs#134.
## 
#### Comments:

@tszming:

> The default Nginx `charset_types` [1] is 
> 
>    `text/html text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml`
> 
> Since the `mime.types` is updated and `application/javascript application/json` are now being used instead of `application/x-javascript`, if the `charset_types` is not updated, then `charset` directive will not work as expected.
> 
> Besides, I have added `text/css` for better handling of non-ASCII in css file. [3]
> 
> [1] http://wiki.nginx.org/HttpCharsetModule#charset_types
> [2] http://forum.nginx.org/read.php?2,52360,52370#msg-52370
> [3] http://trac.nginx.org/nginx/ticket/312
## 

@eric-brechemier:

> Agreed. This is similar to the `gzip_types` directive used in `nginx.conf`.
> 
> The MIME type `application/xml` associated with `rss` files in `mime.types` configuration file should also be included in addition to the MIME type `application/rss+xml`.
