### PR TITLE
Added missing semicolon, removed text/html charset

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,7 @@ http {
   default_type  application/octet-stream;
 
   # Update charset_types due to updated mime.types
-  charset_types text/html text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml text/css application/javascript application/json
+  charset_types text/xml text/plain text/vnd.wap.wml application/x-javascript application/rss+xml text/css application/javascript application/json;
 
   # Format to use in log files
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '


### PR DESCRIPTION
I believe the error was because text/html is implied by default.
