### PR TITLE
Better way to auto set worker_processes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,7 @@ user www www;
 
 # The maximum number of connections for Nginx is calculated by:
 # max_clients = worker_processes * worker_connections
-worker_processes 2;
+worker_processes auto;
 
 # Maximum open file descriptors per process;
 # should be > worker_connections.


### PR DESCRIPTION
Defines the number of worker processes.

The optimal value depends on many factors including (but not limited to) the number of CPU cores, the number of hard disk drives that store data, and load pattern. When one is in doubt, setting it to the number of available CPU cores would be a good start (the value “auto” will try to autodetect it).

The auto parameter is supported starting from versions 1.3.8 and 1.2.5.

Ref: https://github.com/rtCamp/easyengine/issues/100
http://nginx.org/en/docs/ngx_core_module.html#worker_processes
