### PR TITLE
Remove gzip_http_version parameter

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -69,9 +69,6 @@ http {
   # Enable Gzip compressed.
   gzip on;
 
-  # Enable compression both for HTTP/1.0 and HTTP/1.1 (required for CloudFront).
-  gzip_http_version  1.0;
-
   # Compression level (1-9).
   # 5 is a perfect compromise between size and cpu usage, offering about
   # 75% reduction for most ascii files (almost identical to level 9).


### PR DESCRIPTION
The `gzip_http_version` override is no longer needed because CloudFront
now forwards requests using HTTP/1.1. We can remove this line entirely
and let nginx use its default value of 1.1.

Ref: [Request and Response Behavior for Custom Origins > HTTP Version](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustomHTTPVersion)
