### PR TITLE
Add the WOFF2 mime type

### DIFF
--- a/h5bp/location/cross-domain-fonts.conf
+++ b/h5bp/location/cross-domain-fonts.conf
@@ -1,5 +1,5 @@
 # Cross domain webfont access
-location ~* \.(?:ttf|ttc|otf|eot|woff)$ {
+location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
     include h5bp/directive-only/cross-domain-insecure.conf;
 
     # Also, set cache rules for webfonts.

--- a/h5bp/location/expires.conf
+++ b/h5bp/location/expires.conf
@@ -36,7 +36,7 @@ location ~* \.(?:css|js)$ {
 
 # WebFonts
 # If you are NOT using cross-domain-fonts.conf, uncomment the following directive
-# location ~* \.(?:ttf|ttc|otf|eot|woff)$ {
+# location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
 #  expires 1M;
 #  access_log off;
 #  add_header Cache-Control "public";

--- a/mime.types
+++ b/mime.types
@@ -53,6 +53,7 @@ types {
 
 # Web fonts
   application/font-woff                 woff;
+  application/font-woff2                woff2;
   application/vnd.ms-fontobject         eot;
   application/x-font-ttf                ttc ttf;
   font/opentype                         otf;


### PR DESCRIPTION
WOFF 2.0 is available since Chrome 36 and Opera 23.

Here are the details:
https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a
http://dev.w3.org/webfonts/WOFF2/spec/#IMT
