### PR TITLE
Fix typo in `getting-started.md`

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -18,7 +18,7 @@ Apply to the runtime config file:
 
     // /etc/nginx/nginx.conf
 	#user www www;
-	user www-data-www-data;
+	user www-data www-data;
 
 ## Configure logs and pid file
 


### PR DESCRIPTION
User and group name should be separated by a space character.
Otherwise, only one value `www-data-www-data` is passed:

_"If group is omitted, a group whose name equals that of user is used."_
