### PR TITLE
Removed "includeSubDomains"

### DIFF
--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -30,8 +30,9 @@ ssl_session_timeout  24h;
 # Use a higher keepalive timeout to reduce the need for repeated handshakes
 keepalive_timeout 300; # up from 75 secs default
 
-# remember the certificate for a year and automatically connect to HTTPS
-add_header Strict-Transport-Security max-age=31536000;
+# HSTS (HTTP Strict Transport Security)
+# This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.
+#add_header Strict-Transport-Security max-age=31536000;
 
 # This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
 # Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.


### PR DESCRIPTION
As a best practice, Nginx should only direct clients to use the certificate on specified domains. This is because not all servers using other subdomains necessarily listen on 443 and because, unless it is a wildcard certificate, it likely won't be valid on subdomains other than WWW.
