### PR TITLE
Add information on `ngx_pagespeed` and content transformation

### DIFF
--- a/h5bp/directive-only/no-transform.conf
+++ b/h5bp/directive-only/no-transform.conf
@@ -1,2 +1,11 @@
 # Prevent mobile network providers from modifying your site
+#
+# (!) If you are using `ngx_pagespeed`, please note that setting
+# the `Cache-Control: no-transform` response header will prevent
+# `PageSpeed` from rewriting `HTML` files, and, if
+# `pagespeed DisableRewriteOnNoTransform off` is not used, also
+# from rewriting other resources.
+#
+# https://developers.google.com/speed/pagespeed/module/configuration#notransform
+
 add_header "Cache-Control" "no-transform";


### PR DESCRIPTION
Provide information about `ngx_pagespeed` not rewriting any / some of the resources if the `Cache-Control: no-transform` response header is set.

See also:
- https://developers.google.com/speed/pagespeed/module/configuration#notransform
- h5bp/server-configs-apache#46
