### PR TITLE
Move SVG MIME-Type into the "Images" group

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -13,6 +13,7 @@ types {
   image/gif                             gif;
   image/jpeg                            jpeg jpg;
   image/png                             png;
+  image/svg+xml                         svg svgz;
   image/tiff                            tif tiff;
   image/vnd.wap.wbmp                    wbmp;
   image/webp                            webp;
@@ -57,7 +58,6 @@ types {
   application/vnd.ms-fontobject         eot;
   application/x-font-ttf                ttc ttf;
   font/opentype                         otf;
-  image/svg+xml                         svg svgz;
 
 # Other
   application/java-archive              jar war ear;


### PR DESCRIPTION
SVG is primarily an image format. Its usage as a font format is a legacy issue for supporting iOS 3 and iOS 4. In Chrome 38, support for SVG fonts has been removed (http://caniuse.com/#feat=svg-fonts). They have never been supported in Firefox or IE.
