### PR TITLE
Use specific MIME type for '.opus' files

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -4,7 +4,8 @@ types {
   audio/midi                            mid midi kar;
   audio/mp4                             aac f4a f4b m4a;
   audio/mpeg                            mp3;
-  audio/ogg                             oga ogg opus;
+  audio/ogg                             oga ogg;
+  'audio/ogg; codecs=opus'              opus;
   audio/x-realaudio                     ra;
   audio/x-wav                           wav;
 


### PR DESCRIPTION
Files with the `.opus` extension should be served with the MIME type `audio/ogg; codecs=opus` due to the fact that they are not simply Ogg Vorbis files, but will likely be treated that way in older browsers when they are served with the content-type they currently have. The single-quotes surrounding the content-type are necessary to escape the semicolon in it; I tried using a backslash, but it doesn't work.