### PR TITLE
Remove include directive in ssl.example.com

### DIFF
--- a/sites-available/ssl.example.com
+++ b/sites-available/ssl.example.com
@@ -8,8 +8,6 @@ server {
   # listen on both hosts
   server_name example.com www.example.com;
 
-  include h5bp/directive-only/ssl.conf;
-
   # and redirect to the https host (declared below)
   # avoiding http://www -> https://www -> https:// chain.
   return 301 https://example.com$request_uri;


### PR DESCRIPTION
To include the SSL related directives in the port 80 server block seems to be redundant. Because all incoming traffic via port 80 is explicit redirected to the HTTPS host on port 443 where **only** the _secure-connection-magic_ is happen.

Maybe I am missing something, but I tested the configuration under the following system and encountered no negative side effects:

**Server**
- Ubuntu 14.04 LTS
- Nginx 1.7.7 mainline

**Client**
- OS X 10.9.5
- FF 33, Chrome 38, Safari 7
