### PR TITLE
Add MIME-Type for .xsl files

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -51,6 +51,7 @@ types {
 
 # Web feeds
   application/xml                       atom rdf rss xml;
+  application/xslt+xml                  xsl;
 
 # Web fonts
   application/font-woff                 woff;


### PR DESCRIPTION
The correct MIME-Type for XSL files is `application/xslt+xml` according to http://www.w3.org/TR/2007/REC-xslt20-20070123/#media-type-registration.