### PR TITLE
Added accept filter/socket options for SSL servers on FreeBSD and Linux hosts

### DIFF
--- a/sites-available/example.com
+++ b/sites-available/example.com
@@ -15,8 +15,10 @@ server {
 }
 
 server {
-  # listen 80 deferred; # for Linux
+  # listen [::]:80 accept_filter=httpready; # for FreeBSD
   # listen 80 accept_filter=httpready; # for FreeBSD
+  # listen [::]:80 deferred; # for Linux
+  # listen 80 deferred; # for Linux
   listen [::]:80;
   listen 80;
 

--- a/sites-available/ssl.example.com
+++ b/sites-available/ssl.example.com
@@ -27,6 +27,11 @@ server {
 }
 
 server {
+
+  # listen [::]:443 ssl spdy accept_filter=dataready;  # for FreeBSD
+  # listen 443 ssl spdy accept_filter=dataready;  # for FreeBSD
+  # listen [::]:443 ssl spdy deferred;  # for Linux
+  # listen 443 ssl spdy deferred;  # for Linux
   listen [::]:443 ssl spdy;
   listen 443 ssl spdy;
 


### PR DESCRIPTION
As per 'accept_filter=filter' section of http://nginx.org/en/docs/http/ngx_http_core_module.html#listen

More on FreeBSD's accept filters:
http://www.freebsd.org/cgi/man.cgi?accf_http
http://www.freebsd.org/cgi/man.cgi?accf_data

Also added 'defered' (TCP_DEFER_ACCEPT) socket option to SSL server on Linux hosts and organized/commented both platform directives above the default value.

Related to https://github.com/h5bp/server-configs-nginx/blob/master/sites-available/example.com#L19