### PR TITLE
Updated locations to match h5bp's Apache config

### DIFF
--- a/h5bp/location/protect-system-files.conf
+++ b/h5bp/location/protect-system-files.conf
@@ -1,10 +1,13 @@
 # Prevent clients from accessing hidden files (starting with a dot)
 # This is particularly important if you store .htpasswd files in the site hierarchy
-location ~* (?:^|/)\. {
+# Access to `/.well-known/` is allowed.
+# https://www.mnot.net/blog/2010/04/07/well-known
+# https://tools.ietf.org/html/rfc5785
+location ~* /\.(?!well-known\/) {
     deny all;
 }
 
 # Prevent clients from accessing to backup/config/source files
-location ~* (?:\.(?:bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist)|~)$ {
+location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
     deny all;
 }


### PR DESCRIPTION
See https://github.com/h5bp/server-configs-apache/issues/31 for `well-known` change.

The syntax of the first location regex has changed slightly. I don't really understand the reason for having `(?:^|/)` in the beginning. After quick testing my version seems to be working fine, but you might want to double check it.