### PR TITLE
Added FreeBSD w/ ZFS performance instructions

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -57,6 +57,9 @@ http {
 
   # Speed up file transfers by using sendfile() to copy directly
   # between descriptors rather than using read()/write().
+  # For performance reasons, on FreeBSD systems w/ ZFS 
+  # this option should be disabled as ZFS's ARC caches
+  # frequently used files in RAM by default.
   sendfile        on;
 
   # Tell Nginx not to send out partial frames; this increases throughput


### PR DESCRIPTION
On FreeBSD systems with ZFS, sendfile() is useless as ZFS's caching subsystem (adaptive replacement cache a.k.a ARC) already caches most frequently used files in RAM. Disabling sendfile() avoids redundant data caching. 

References: 
* https://calomel.org/nginx.html
* http://blog.vx.sk/uploads/conferences/EuroBSDcon2012/zfs-tuning-handout.pdf