### PR TITLE
preload added to ssl.conf

### DIFF
--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -35,6 +35,9 @@ keepalive_timeout 300; # up from 75 secs default
 #add_header Strict-Transport-Security "max-age=31536000;";
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
 #add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+# This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
+# Recommend is also to use preload service
+#add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload;";
 
 # This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
 # Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.


### PR DESCRIPTION
Not part of the specification, but recommented.
The `preload` flag indicates the site owner's consent to have their domain preloaded. The site owner still needs to then go and submit the domain to the list.
https://hstspreload.appspot.com/
