### PR TITLE
Add default server to handle requests for unknown hosts via HTTPS

### DIFF
--- a/sites-available/no-default
+++ b/sites-available/no-default
@@ -7,5 +7,10 @@
 
 server {
   listen 80 default_server;
+
+  # If you're using HTTPS, uncomment the following directives
+  # listen 443 ssl default_server;
+  # include h5bp/directive-only/ssl.conf;
+
   return 444;
 }


### PR DESCRIPTION
If there's no HTTPS server with `default_server` option in the `listen` directive configured and a client requests an unknown host establishing a secure connection, nginx chooses one of the existing servers listening on the same port to handle the user request.

Such behavior may not be desirable, and this fix makes sure we have default server which handles both non-secure connections and secure connections.