### PR TITLE
Improve comments in nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -15,7 +15,7 @@ worker_rlimit_nofile 8192;
 
 events {
   # If you need more connections than this, you start optimizing your OS.
-  # That's probably the point at which you hire people who are smarter than you at this is *a lot* of requests.
+  # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
   # Should be < worker_rlimit_nofile.
   worker_connections 8000;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,32 +1,30 @@
-# nginx Configuration File
-# http://wiki.nginx.org/Configuration
+# Configuration File - Nginx Server Configs
+# http://nginx.org/en/docs/dirindex.html
 
-# Run as a less privileged user for security reasons.
+# Run as a unique, less privileged user for security reasons.
 user www www;
 
-# How many worker threads to run;
-# "auto" sets it to the number of CPU cores available in the system, and
-# offers the best performance. Don't set it higher than the number of CPU
-# cores if changing this parameter.
-
-# The maximum number of connections for Nginx is calculated by:
-# max_clients = worker_processes * worker_connections
+# Sets the worker threads to the number of CPU cores available in the system for best performance.
+# Should be > the number of CPU cores.
+# Maximum number of connections = worker_processes * worker_connections
 worker_processes auto;
 
-# Maximum open file descriptors per process;
-# should be > worker_connections.
+# Maximum number of open files per worker process.
+# Should be > worker_connections.
 worker_rlimit_nofile 8192;
 
 events {
-  # When you need > 8000 * cpu_cores connections, you start optimizing your OS,
-  # and this is probably the point at which you hire people who are smarter than
-  # you, as this is *a lot* of requests.
+  # If you need more connections than this, you start optimizing your OS.
+  # That's probably the point at which you hire people who are smarter than you at this is *a lot* of requests.
+  # Should be < worker_rlimit_nofile.
   worker_connections 8000;
 }
 
-# Default error log file
-# (this is only used when you don't override error_log on a server{} level)
+# Log errors and warnings to this file
+# This is only used when you don't override it on a server{} level
 error_log  logs/error.log warn;
+
+# The file storing the process ID of the main process
 pid        /var/run/nginx.pid;
 
 http {
@@ -34,25 +32,26 @@ http {
   # Hide nginx version information.
   server_tokens off;
 
-  # Define the MIME types for files.
+  # Specify MIME types for files.
   include       mime.types;
   default_type  application/octet-stream;
 
-  # Update charset_types due to updated mime.types
+  # Update charset_types to match updated mime.types.
+  # text/html is always included by charset module.
   charset_types text/css text/plain text/vnd.wap.wml application/javascript application/json application/rss+xml application/xml;
 
-  # Format to use in log files
+  # Include $http_x_forwarded_for within default format used in log files
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 
-  # Default log file
-  # (this is only used when you don't override access_log on a server{} level)
+  # Log access to this file
+  # This is only used when you don't override it on a server{} level
   access_log logs/access.log main;
 
-  # How long to allow each connection to stay idle; longer values are better
-  # for each individual client, particularly for SSL, but means that worker
-  # connections are tied up longer. (Default: 75s)
+  # How long to allow each connection to stay idle.
+  # Longer values are better for each individual client, particularly for SSL,
+  # but means that worker connections are tied up longer.
   keepalive_timeout 20s;
 
   # Speed up file transfers by using sendfile() to copy directly
@@ -62,19 +61,16 @@ http {
   # frequently used files in RAM by default.
   sendfile        on;
 
-  # Tell Nginx not to send out partial frames; this increases throughput
-  # since TCP frames are filled up before being sent out. (adds TCP_CORK)
+  # Don't send out partial frames; this increases throughput
+  # since TCP frames are filled up before being sent out.
   tcp_nopush      on;
 
-
-  # Compression
-
-  # Enable Gzip compressed.
+  # Enable gzip compression.
   gzip on;
 
   # Compression level (1-9).
-  # 5 is a perfect compromise between size and cpu usage, offering about
-  # 75% reduction for most ascii files (almost identical to level 9).
+  # 5 is a perfect compromise between size and CPU usage, offering about
+  # 75% reduction for most ASCII files (almost identical to level 9).
   gzip_comp_level    5;
 
   # Don't compress anything that's already small and unlikely to shrink much
@@ -118,7 +114,7 @@ http {
     text/vtt
     text/x-component
     text/x-cross-domain-policy;
-  # text/html is always compressed by HttpGzipModule
+  # text/html is always compressed by gzip module
 
   # This should be turned on if you are going to have pre-compressed copies (.gz) of
   # static files available. If not it should be left off as it will cause extra I/O


### PR DESCRIPTION
This improves the comments in nginx.conf by simplifying them, making it easier to read, etc.

On a side note, perhaps we should move all/most of the comments in here over to the documentation? It would reduce the file size and make the documentation more useful.