### PR TITLE
Specify that keepalive_timeout is in seconds

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,7 +53,7 @@ http {
   # How long to allow each connection to stay idle; longer values are better
   # for each individual client, particularly for SSL, but means that worker
   # connections are tied up longer. (Default: 65)
-  keepalive_timeout 20;
+  keepalive_timeout 20s;
 
   # Speed up file transfers by using sendfile() to copy directly
   # between descriptors rather than using read()/write().

--- a/nginx.conf
+++ b/nginx.conf
@@ -52,7 +52,7 @@ http {
 
   # How long to allow each connection to stay idle; longer values are better
   # for each individual client, particularly for SSL, but means that worker
-  # connections are tied up longer. (Default: 65)
+  # connections are tied up longer. (Default: 75s)
   keepalive_timeout 20s;
 
   # Speed up file transfers by using sendfile() to copy directly


### PR DESCRIPTION
This specifies that the keep alive timeout option is in seconds. This follows the default value format (75s)