### PR TITLE
Correct syntax for keepalive_timeout

### DIFF
--- a/h5bp/directive-only/spdy.conf
+++ b/h5bp/directive-only/spdy.conf
@@ -5,7 +5,7 @@
 add_header Alternate-Protocol  443:npn-spdy/3;
 
 # Adjust connection keepalive for SPDY clients:
-spdy_keepalive_timeout 300; # up from 180 secs default
+spdy_keepalive_timeout 300s; # up from 180 secs default
 
 # enable SPDY header compression
 spdy_headers_comp 6;

--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -28,7 +28,7 @@ ssl_session_timeout  24h;
 #ssl_session_tickets off;
 
 # Use a higher keepalive timeout to reduce the need for repeated handshakes
-keepalive_timeout 300; # up from 75 secs default
+keepalive_timeout 300s; # up from 75 secs default
 
 # HSTS (HTTP Strict Transport Security)
 # This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.


### PR DESCRIPTION
It doesn't seem to be a fatal error, but the `keepalive_timeout` value actually requires "s" (for seconds). Another occurrence of this was fixed in 35434b3361b04beb028f602c78a9331ef4967a0d but these slipped through.

See: http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout