### PR TITLE
Updated ssl.exemple.com to use http2 instead of spdy

### DIFF
--- a/sites-available/ssl.example.com
+++ b/sites-available/ssl.example.com
@@ -14,8 +14,8 @@ server {
 }
 
 server {
-  listen [::]:443 ssl spdy;
-  listen 443 ssl spdy;
+  listen [::]:443 ssl http2;
+  listen 443 ssl http2;
 
   # listen on the wrong host
   server_name www.example.com;
@@ -28,12 +28,12 @@ server {
 
 server {
 
-  # listen [::]:443 ssl spdy accept_filter=dataready;  # for FreeBSD
-  # listen 443 ssl spdy accept_filter=dataready;  # for FreeBSD
-  # listen [::]:443 ssl spdy deferred;  # for Linux
-  # listen 443 ssl spdy deferred;  # for Linux
-  listen [::]:443 ssl spdy;
-  listen 443 ssl spdy;
+  # listen [::]:443 ssl http2 accept_filter=dataready;  # for FreeBSD
+  # listen 443 ssl http2 accept_filter=dataready;  # for FreeBSD
+  # listen [::]:443 ssl http2 deferred;  # for Linux
+  # listen 443 ssl http2 deferred;  # for Linux
+  listen [::]:443 ssl http2;
+  listen 443 ssl http2;
 
   # The host name to respond to
   server_name example.com;


### PR DESCRIPTION
http2 is available in nginx since [nginx 1.9.5.](https://www.nginx.com/blog/nginx-1-9-5/) Therefore it's better to use the standard.