### PR TITLE
Always add security-relevant headers to the response, regardless of the response code (implements #147)

### DIFF
--- a/h5bp/directive-only/extra-security.conf
+++ b/h5bp/directive-only/extra-security.conf
@@ -1,17 +1,17 @@
 # The X-Frame-Options header indicates whether a browser should be allowed
 # to render a page within a frame or iframe.
-add_header X-Frame-Options SAMEORIGIN;
+add_header X-Frame-Options SAMEORIGIN always;
 
 # MIME type sniffing security protection
 #	There are very few edge cases where you wouldn't want this enabled.
-add_header X-Content-Type-Options nosniff;
+add_header X-Content-Type-Options nosniff always;
 
 # The X-XSS-Protection header is used by Internet Explorer version 8+
 # The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
-add_header X-XSS-Protection "1; mode=block";
+add_header X-XSS-Protection "1; mode=block" always;
 
 # with Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
 # you can tell the browser that it can only download content from the domains you explicitly allow
 # CSP can be quite difficult to configure, and cause real issues if you get it wrong
 # There is website that helps you generate a policy here http://cspisawesome.com/
-# add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;";
+# add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;" always;

--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -32,12 +32,12 @@ keepalive_timeout 300s; # up from 75 secs default
 
 # HSTS (HTTP Strict Transport Security)
 # This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.
-#add_header Strict-Transport-Security "max-age=31536000;";
+#add_header Strict-Transport-Security "max-age=31536000;" always;
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
-#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;" always;
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
 # Recommend is also to use preload service
-#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload;";
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload;" always;
 
 # This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
 # Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.


### PR DESCRIPTION
From nginx' add_header documentation:
```
add_header Adds the specified field to a response header provided that
the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307.
```
At least for all security-relevant headers this should not be the case
and the header should always be added.