### PR TITLE
Added mime types for JPEG-XR, markdown, and CSV

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -35,6 +35,7 @@ types {
     image/bmp                             bmp;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
+    image/jxr                             jxr hdp wdp;
     image/png                             png;
     image/svg+xml                         svg svgz;
     image/tiff                            tif tiff;
@@ -122,7 +123,9 @@ types {
     application/xslt+xml                  xsl;
     application/zip                       zip;
     text/css                              css;
+    text/csv                              csv;
     text/html                             htm html shtml;
+    text/markdown                         md;
     text/mathml                           mml;
     text/plain                            txt;
     text/vcard                            vcard vcf;


### PR DESCRIPTION
JPEG-XR: http://www.iana.org/assignments/provisional-standard-media-types/provisional-standard-media-types.xhtml
Markdown: https://tools.ietf.org/html/rfc7763
CSV: https://tools.ietf.org/html/rfc7111

There are different MIME types for JPEG-XR. I chose image/jxr because that is the type Microsoft Edge and IE 11 are using in their request headers.
