### PR TITLE
No trailing semicolon per RFC 6797

### DIFF
--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -32,12 +32,12 @@ keepalive_timeout 300s; # up from 75 secs default
 
 # HSTS (HTTP Strict Transport Security)
 # This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.
-#add_header Strict-Transport-Security "max-age=31536000;";
+#add_header Strict-Transport-Security "max-age=31536000";
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
-#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
 # This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
 # Recommend is also to use preload service
-#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload;";
+#add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
 
 # This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
 # Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.


### PR DESCRIPTION
These lines should not include trailing semicolons. https://tools.ietf.org/html/rfc6797
