### PR TITLE
Updated gzip_types and charset_types code convention

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,7 +38,14 @@ http {
 
   # Update charset_types to match updated mime.types.
   # text/html is always included by charset module.
-  charset_types text/css text/plain text/vnd.wap.wml application/javascript application/json application/rss+xml application/xml;
+  charset_types
+    text/css
+    text/plain
+    text/vnd.wap.wml
+    application/javascript
+    application/json
+    application/rss+xml
+    application/xml;
 
   # Include $http_x_forwarded_for within default format used in log files
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -89,6 +96,7 @@ http {
   gzip_vary          on;
 
   # Compress all output labeled with one of the following MIME-types.
+  # text/html is always compressed by gzip module.
   gzip_types
     application/atom+xml
     application/javascript
@@ -114,7 +122,6 @@ http {
     text/vtt
     text/x-component
     text/x-cross-domain-policy;
-  # text/html is always compressed by gzip module
 
   # This should be turned on if you are going to have pre-compressed copies (.gz) of
   # static files available. If not it should be left off as it will cause extra I/O


### PR DESCRIPTION
… both are now using the same code convention. Each type in its own row and `text/html` comment at the top (where all comments are placed).
