### PR TITLE
redirect securely by setting HSTS header on both hosts

### DIFF
--- a/sites-available/ssl.example.com
+++ b/sites-available/ssl.example.com
@@ -8,9 +8,8 @@ server {
   # listen on both hosts
   server_name example.com www.example.com;
 
-  # and redirect to the https host (declared below)
-  # avoiding http://www -> https://www -> https:// chain.
-  return 301 https://example.com$request_uri;
+  # and redirect to the https equivalent (declared below).
+  return 301 https://$host$request_uri;
 }
 
 server {


### PR DESCRIPTION
The current `ssl.example.com` config reads like this:

```
# listen on both hosts
server_name example.com www.example.com;

# and redirect to the https host (declared below)
# avoiding http://www -> https://www -> https:// chain.
return 301 https://example.com$request_uri;
```

If the [HSTS config](https://github.com/h5bp/server-configs-nginx/blob/master/h5bp/directive-only/ssl.conf) is uncommented and you access `http://www.example.com` you'll be immediately redirected to `httpS://example.com`. The HSTS header will never be set for `www.example.com`, thus making future canonical redirects (to the "correct" host) insecure.

A more detailed explanation can be found here:
https://sentinelstand.com/article/http-strict-transport-security-hsts-canonical-www-redirects

This PR corrects this by creating the following redirect flow:

* `http://www.example.com` → `https://www.example.com*` → `https://example.com*`
* `http://example.com` → `https://example.com*`

where asterisk denotes setting the HSTS header.

Please tell me if you think a small note/explanation should be added as well.