### PR TITLE
Use Cache-Control instead of Expires

### DIFF
--- a/doc/common-problems.md
+++ b/doc/common-problems.md
@@ -148,7 +148,6 @@ will be a 404. The reason for this is that H5bp's basic ruleset includes, for ex
 	location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
 		expires 1M;
 		access_log off;
-		add_header Cache-Control "public";
 	}
 
 Which will _also_ capture any dynamic requests matching that url pattern and not
@@ -166,7 +165,6 @@ Modifying (all) location blocks as follows:
 
 		expires 1M;
 		access_log off;
-		add_header Cache-Control "public";
 	}
 
 Will make Nginx pass requests for files that don't exist to the application.

--- a/h5bp/location/cross-domain-fonts.conf
+++ b/h5bp/location/cross-domain-fonts.conf
@@ -7,7 +7,6 @@ location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
   # See http://wiki.nginx.org/HttpCoreModule#location
   # And https://github.com/h5bp/server-configs/issues/85
   # And https://github.com/h5bp/server-configs/issues/86
-  expires 1M;
   access_log off;
-  add_header Cache-Control "public";
+  add_header Cache-Control "max-age=2592000";
 }

--- a/h5bp/location/expires.conf
+++ b/h5bp/location/expires.conf
@@ -20,9 +20,8 @@ location ~* \.(?:rss|atom)$ {
 
 # Media: images, icons, video, audio, HTC
 location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
-  expires 1M;
   access_log off;
-  add_header Cache-Control "public";
+  add_header Cache-Control "max-age=2592000";
 }
 
 # CSS and Javascript

--- a/h5bp/location/expires.conf
+++ b/h5bp/location/expires.conf
@@ -10,12 +10,12 @@
 
 # cache.appcache, your document html and data
 location ~* \.(?:manifest|appcache|html?|xml|json)$ {
-  expires -1;
+  add_header Cache-Control "max-age=0";
 }
 
 # Feed
 location ~* \.(?:rss|atom)$ {
-  expires 1h;
+  add_header Cache-Control "max-age=3600";
 }
 
 # Media: images, icons, video, audio, HTC
@@ -26,13 +26,13 @@ location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
 
 # CSS and Javascript
 location ~* \.(?:css|js)$ {
-  expires 1y;
+  add_header Cache-Control "max-age=31536000";
   access_log off;
 }
 
 # WebFonts
 # If you are NOT using cross-domain-fonts.conf, uncomment the following directive
 # location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
-#  expires 1M;
+#  add_header Cache-Control "max-age=2592000";
 #  access_log off;
 # }


### PR DESCRIPTION
Configuration and documentation updates for:

- Removing `Cache-Control: "public"`, as it is implicit if `max-age` is provided
- Replacing `expires` with `Cache-Control: "max-age=x"` as the latter supersedes the former in HTTP/1.1

These are both is current best practices according to [Google's 2016 web performance documentation](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching) and [mnot's 2007 (!) blog post](https://www.mnot.net/blog/2007/05/15/expires_max-age) about HTTP caching mechanisms.

A previous commit did some of this, but appears to have missed a few references. There are still a few references to `expires` in the documentation because those sections will need to be rewritten.