### PR TITLE
Add non-matching server_name for no-default config

### DIFF
--- a/sites-available/no-default
+++ b/sites-available/no-default
@@ -1,12 +1,13 @@
 # Drop requests for unknown hosts
 #
 # If no default server is defined, nginx will use the first found server.
-# To prevent host header attacks, or other potential problems when an unknown 
-# servername is used in a request, it's recommended to drop the request 
+# To prevent host header attacks, or other potential problems when an unknown
+# servername is used in a request, it's recommended to drop the request
 # returning 444 "no response".
 
 server {
-  listen 80 default_server;
+  listen [::]:80 default_server deferred;
+  listen 80 default_server deferred;
   server_name _;
   return 444;
 }

--- a/sites-available/no-default
+++ b/sites-available/no-default
@@ -7,5 +7,6 @@
 
 server {
   listen 80 default_server;
+  server_name _;
   return 444;
 }

--- a/sites-available/ssl.no-default
+++ b/sites-available/ssl.no-default
@@ -7,6 +7,7 @@
 
 server {
   listen 443 ssl default_server;
+  server_name _;
   include h5bp/directive-only/ssl.conf;
   return 444;
 }

--- a/sites-available/ssl.no-default
+++ b/sites-available/ssl.no-default
@@ -6,6 +6,7 @@
 # returning 444 "no response".
 
 server {
+  listen [::]:443 ssl default_server;
   listen 443 ssl default_server;
   server_name _;
   include h5bp/directive-only/ssl.conf;


### PR DESCRIPTION
Without the server_name directive the no-default server would match instantly as soon as it is tested and thus server configs later in the match queue would not be considered, effectively disabling them. An underscore as server_name is guaranteed not to match since it is not a valid server name.
Now, every server config is considered and if none matches, the no-default config is chosen due to the default_server flag.