### PR TITLE
Add path to self signed certificate for ssl.no-default server block. 

### DIFF
--- a/sites-available/README.md
+++ b/sites-available/README.md
@@ -9,4 +9,9 @@ example.com (handles traffic from both www.example.com and example.com)
 foobar.com (as above)
 test.foobar.com (handles traffic from both www.test.foobar.com and test.foobar.com)
 ```
+The HTTPS no-default server config requires a valid certificate (self signed will suffice).
+One can generate the certificate with: 
+```
+sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt
+```
 

--- a/sites-available/ssl.no-default
+++ b/sites-available/ssl.no-default
@@ -8,5 +8,10 @@
 server {
   listen 443 ssl default_server;
   include h5bp/directive-only/ssl.conf;
+
+  ssl_certificate /etc/nginx/ssl/nginx.crt;
+  ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
   return 444;
 }
+


### PR DESCRIPTION
Based on some issues with multiple hosts (HTTPS) on a single nginx server, I had to add (self signed in my case) certificates for the ssl.no-default server block.