### PR TITLE
Merge listen directives with ipv6only=off

### DIFF
--- a/conf.d/.default.conf
+++ b/conf.d/.default.conf
@@ -10,14 +10,12 @@
 # returning 444 "no response".
 
 server {
-  listen [::]:443 ssl default_server;
-  listen 443 ssl default_server;
+  listen [::]:443 ssl default_server ipv6only=off;
 
   server_name _;
 
   include h5bp/ssl/ssl_engine.conf;
   include h5bp/ssl/certificate_files.conf;
   include h5bp/ssl/policy_intermediate.conf;
-
   return 444;
 }

--- a/conf.d/.default.conf
+++ b/conf.d/.default.conf
@@ -10,7 +10,7 @@
 # returning 444 "no response".
 
 server {
-  listen [::]:443 ssl default_server ipv6only=off deferred;
+  listen [::]:443 ssl default_server ipv6only=off;
 
   server_name _;
 

--- a/conf.d/.default.conf
+++ b/conf.d/.default.conf
@@ -17,5 +17,6 @@ server {
   include h5bp/ssl/ssl_engine.conf;
   include h5bp/ssl/certificate_files.conf;
   include h5bp/ssl/policy_intermediate.conf;
+
   return 444;
 }

--- a/conf.d/.default.conf
+++ b/conf.d/.default.conf
@@ -10,7 +10,7 @@
 # returning 444 "no response".
 
 server {
-  listen [::]:443 ssl default_server ipv6only=off;
+  listen [::]:443 ssl default_server ipv6only=off deferred;
 
   server_name _;
 

--- a/conf.d/no-ssl.default.conf
+++ b/conf.d/no-ssl.default.conf
@@ -16,8 +16,7 @@
 #     https://observatory.mozilla.org/faq/
 
 server {
-  listen [::]:80 default_server deferred;
-  listen 80 default_server deferred;
+  listen [::]:80 default_server ipv6only=off deferred;
 
   server_name _;
 

--- a/conf.d/templates/example.com.conf
+++ b/conf.d/templates/example.com.conf
@@ -10,8 +10,7 @@
 # the right one.
 # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#server-name-if
 server {
-  listen [::]:443 ssl http2;
-  listen 443 ssl http2;
+  listen [::]:443 ssl http2 ipv6only=off;
 
   server_name www.example.com;
 
@@ -28,8 +27,7 @@ server {
   # listen 443 ssl http2 accept_filter=dataready;  # for FreeBSD
   # listen [::]:443 ssl http2 deferred;  # for Linux
   # listen 443 ssl http2 deferred;  # for Linux
-  listen [::]:443 ssl http2;
-  listen 443 ssl http2;
+  listen [::]:443 ssl http2 ipv6only=off;
 
   # The host name to respond to
   server_name example.com;

--- a/conf.d/templates/no-ssl.example.com.conf
+++ b/conf.d/templates/no-ssl.example.com.conf
@@ -10,8 +10,7 @@
 # the right one.
 # https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#server-name-if
 server {
-  listen [::]:80;
-  listen 80;
+  listen [::]:80 ipv6only=off;
 
   server_name www.example.com;
 
@@ -23,8 +22,7 @@ server {
   # listen 80 accept_filter=httpready; # for FreeBSD
   # listen [::]:80 deferred; # for Linux
   # listen 80 deferred; # for Linux
-  listen [::]:80;
-  listen 80;
+  listen [::]:80 ipv6only=off;
 
   # The host name to respond to
   server_name example.com;

--- a/test/vhosts/default.conf
+++ b/test/vhosts/default.conf
@@ -8,7 +8,7 @@ server {
 
 
 server {
-  listen [::]:443 ssl default_server ipv6only=off deferred;
+  listen [::]:443 ssl default_server ipv6only=off;
 
   server_name _;
 

--- a/test/vhosts/default.conf
+++ b/test/vhosts/default.conf
@@ -1,6 +1,5 @@
 server {
-  listen [::]:80 default_server deferred;
-  listen 80 default_server deferred;
+  listen [::]:80 default_server ipv6only=off deferred;
 
   server_name _;
 
@@ -9,8 +8,7 @@ server {
 
 
 server {
-  listen [::]:443 ssl default_server;
-  listen 443 ssl default_server;
+  listen [::]:443 ssl default_server ipv6only=off deferred;
 
   server_name _;
 

--- a/test/vhosts/secure.server.localhost.conf
+++ b/test/vhosts/secure.server.localhost.conf
@@ -1,6 +1,5 @@
 server {
-  listen [::]:443 ssl http2;
-  listen 443 ssl http2;
+  listen [::]:443 ssl http2 ipv6only=off;
 
   server_name www.secure.server.localhost;
 
@@ -12,8 +11,7 @@ server {
 }
 
 server {
-  listen [::]:443 ssl http2;
-  listen 443 ssl http2;
+  listen [::]:443 ssl http2 ipv6only=off;
 
   server_name secure.server.localhost;
 

--- a/test/vhosts/server.localhost.conf
+++ b/test/vhosts/server.localhost.conf
@@ -1,6 +1,5 @@
 server {
-  listen [::]:80;
-  listen 80;
+  listen [::]:80 ipv6only=off;
 
   server_name www.server.localhost;
 
@@ -8,8 +7,7 @@ server {
 }
 
 server {
-  listen [::]:80;
-  listen 80;
+  listen [::]:80 ipv6only=off;
 
   server_name server.localhost;
 

--- a/test/vhosts/www-server.localhost.conf
+++ b/test/vhosts/www-server.localhost.conf
@@ -1,6 +1,5 @@
 server {
-  listen [::]:80;
-  listen 80;
+  listen [::]:80 ipv6only=off;
 
   server_name www-server.localhost;
 


### PR DESCRIPTION
`ssl.no-default` and `no-default` both changed to keep things similiar.
Verified on CentOS 7/nginx 1.12.0
Code from @Rowno 