### PR TITLE
Adding MIME types for OpenDocument

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -70,6 +70,16 @@ types {
     application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
     application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
 
+  # OpenDocument
+
+    application/vnd.oasis.opendocument.chart                   odc;
+    application/vnd.oasis.opendocument.database                odb;
+    application/vnd.oasis.opendocument.formula                 odf;
+    application/vnd.oasis.opendocument.graphics                odg;
+    application/vnd.oasis.opendocument.image                   odi;
+    application/vnd.oasis.opendocument.presentation            odp;
+    application/vnd.oasis.opendocument.spreadsheet             ods;
+    application/vnd.oasis.opendocument.text                    odt;
 
   # Web fonts
 


### PR DESCRIPTION
Several governments around the world have introduced policies of partial or complete adoption of the OpenDocument standard, so having MIME types for Microsoft Office but no MIME types for OpenDocument seems arbitrary and insufficient.

These are the MIME types I did include:
```
    application/vnd.oasis.opendocument.chart                   odc;
    application/vnd.oasis.opendocument.database                odb;
    application/vnd.oasis.opendocument.formula                 odf;
    application/vnd.oasis.opendocument.graphics                odg;
    application/vnd.oasis.opendocument.image                   odi;
    application/vnd.oasis.opendocument.presentation            odp;
    application/vnd.oasis.opendocument.spreadsheet             ods;
    application/vnd.oasis.opendocument.text                    odt;
```
These are the MIME types I did _not_ include.
```
    application/vnd.oasis.opendocument.chart-template          otc;
    application/vnd.oasis.opendocument.formula-template       odft;
    application/vnd.oasis.opendocument.graphics-template       otg;
    application/vnd.oasis.opendocument.image-template          oti;
    application/vnd.oasis.opendocument.presentation-template   otp;
    application/vnd.oasis.opendocument.spreadsheet-template    ots;
    application/vnd.oasis.opendocument.text-master             otm;
    application/vnd.oasis.opendocument.text-template           ott;
    application/vnd.oasis.opendocument.text-web                oth;
    application/vnd.openofficeorg.extension                    oxt;
```