### PR TITLE
Remove deprecated ciphers and protocols

### DIFF
--- a/h5bp/directive-only/ssl.conf
+++ b/h5bp/directive-only/ssl.conf
@@ -1,9 +1,9 @@
 # Protect against the BEAST and POODLE attacks by not using SSLv3 at all. If you need to support older browsers (IE6) you may need to add
 # SSLv3 to the list of protocols below.
-ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
+ssl_protocols              TLSv1.2;
 
 # Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
-ssl_ciphers                ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+ssl_ciphers                ECDHE+CHACHA20:ECDHE+AES;
 ssl_prefer_server_ciphers  on;
 
 # Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.


### PR DESCRIPTION
TLSv1.0 & TLSv1.1 suffer from [POODLE](https://blog.qualys.com/ssllabs/2014/12/08/poodle-bites-tls) and other [padding oracle attack](https://blog.cloudflare.com/padding-oracles-and-the-decline-of-cbc-mode-ciphersuites/)
You need to support only TLSv1.2 to expect closing those weakness (and use only AEAD cipher suite in case of padding oracle).

The same, non PFS cipher suite is not at all recommended (see heartbleed effect).
DHE support [is dropped](https://www.digicert.com/blog/google-plans-to-deprecate-dhe-cipher-suites/) from any decent user agent and can lead to [mitm attack](https://media.ccc.de/v/32c3-7288-logjam_diffie-hellman_discrete_logs_the_nsa_and_you#t=1357) (arround ~25min in the video) with only one side supporting weak cipher suite.
3DES is deprecated and suffer from [sweet32](https://sweet32.info/)

So I recommend using only the `EECDH+CHACHA20:EECDH+AES` cipher suite, which has [quite good compatibility](https://cryptcheck.fr/suite/EECDH+CHACHA20:EECDH+AES) and a very better security than the actual cipher suite.