### PR TITLE
Replace location block `add_header` directives with `expires` directives

### DIFF
--- a/h5bp/location/cross-domain-fonts.conf
+++ b/h5bp/location/cross-domain-fonts.conf
@@ -8,5 +8,5 @@ location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
   # And https://github.com/h5bp/server-configs/issues/85
   # And https://github.com/h5bp/server-configs/issues/86
   access_log off;
-  add_header Cache-Control "max-age=2592000";
+  expires 1M;
 }

--- a/h5bp/location/expires.conf
+++ b/h5bp/location/expires.conf
@@ -10,36 +10,36 @@
 
 # cache.appcache, your document html and data
 location ~* \.(?:manifest|appcache|html?|xml|json)$ {
-  add_header Cache-Control "max-age=0";
+  expires 0;
 }
 
 # Feed
 location ~* \.(?:rss|atom)$ {
-  add_header Cache-Control "max-age=3600";
+  expires 1h;
 }
 
 # Media: images, icons, video, audio, HTC
 location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
   access_log off;
-  add_header Cache-Control "max-age=2592000";
+  expires 1M;
 }
 
 # Media: svgz files are already compressed.
 location ~* \.svgz$ {
   access_log off;
   gzip off;
-  add_header Cache-Control "max-age=2592000";
+  expires 1M;
 }
 
 # CSS and Javascript
 location ~* \.(?:css|js)$ {
-  add_header Cache-Control "max-age=31536000";
+  expires 1y;
   access_log off;
 }
 
 # WebFonts
 # If you are NOT using cross-domain-fonts.conf, uncomment the following directive
 # location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
-#  add_header Cache-Control "max-age=2592000";
+#  expires 1M;
 #  access_log off;
 # }


### PR DESCRIPTION
As explained in https://github.com/h5bp/server-configs-nginx/issues/193, an [`add_header`](http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header) directive inside a `location` block will prevent `add_header` directives from outside the block from being inherited. The [`expires`](http://nginx.org/en/docs/http/ngx_http_headers_module.html#expires) directive sets both the "Expires" and "Cache-Control" response headers without interfering with other headers.

As pointed out in https://github.com/h5bp/server-configs-nginx/pull/168, the Cache-Control header supersedes the Expires header, and all modern browsers support Cache-Control, so Expires is not really necessary. However, there is little cost to adding Expires in addition to Cache-Control, and the benefit gained is trading the pitfalls of `add_header` inheritance for the simplicity of the `expires` directive.