### PR TITLE
Case-sensitive match for /.well-known/ regex

### DIFF
--- a/h5bp/location/protect-system-files.conf
+++ b/h5bp/location/protect-system-files.conf
@@ -3,7 +3,7 @@
 # Access to `/.well-known/` is allowed.
 # https://www.mnot.net/blog/2010/04/07/well-known
 # https://tools.ietf.org/html/rfc5785
-location ~* /\.(?!well-known\/) {
+location ~ /\.(?!well-known\/) {
   deny all;
 }
 


### PR DESCRIPTION
The match for location /.well-known/acme-challenge/ should be case sensitive according to [ACME spec](https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#user-content-http-challenge).