### PR TITLE
Add IPv4 listen directive to no-default

### DIFF
--- a/sites-available/no-default
+++ b/sites-available/no-default
@@ -7,5 +7,6 @@
 
 server {
   listen [::]:80 default_server deferred;
+  listen :80 default_server deferred;
   return 444;
 }


### PR DESCRIPTION
Closes #178

This PR has the same goal as #179 but doesn't use `ipv6only=off` which can cause issues ( see https://github.com/h5bp/server-configs-nginx/pull/169#issuecomment-270502436 and https://github.com/h5bp/server-configs-nginx/pull/179#issuecomment-328713502).

/cc @AD7six @fullyint @t0str
