### PR TITLE
Add mime types for Macromedia/Adobe Shockwave Player and FutureSplash

### DIFF
--- a/mime.types
+++ b/mime.types
@@ -121,6 +121,7 @@ types {
     application/x-director                cct;
     application/x-director                cxt;
     application/x-director                w3d;
+    application/x-director                fgd;
     application/x-director                swa;
     application/x-stuffit                 sit;
     application/x-tcl                     tcl tk;

--- a/mime.types
+++ b/mime.types
@@ -114,6 +114,7 @@ types {
     application/x-redhat-package-manager  rpm;
     application/x-sea                     sea;
     application/x-shockwave-flash         swf;
+    application/futuresplash              spl;
     application/x-director                dir;
     application/x-director                dcr;
     application/x-director                dxr;

--- a/mime.types
+++ b/mime.types
@@ -114,6 +114,14 @@ types {
     application/x-redhat-package-manager  rpm;
     application/x-sea                     sea;
     application/x-shockwave-flash         swf;
+    application/x-director                dir;
+    application/x-director                dcr;
+    application/x-director                dxr;
+    application/x-director                cst;
+    application/x-director                cct;
+    application/x-director                cxt;
+    application/x-director                w3d;
+    application/x-director                swa;
     application/x-stuffit                 sit;
     application/x-tcl                     tcl tk;
     application/x-x509-ca-cert            crt der pem;


### PR DESCRIPTION
This is kind of ironic, giving the repository is about embracing newer technologies. There are, and will forever always be, historical websites that keep these older technologies alive. Like online game emulation for example. This PR adds mime types for Shockwave and FutureSplash content.