### PR TITLE
Add eleptic curves for modern profile preset

### DIFF
--- a/h5bp/ssl/policy_modern.conf
+++ b/h5bp/ssl/policy_modern.conf
@@ -14,4 +14,5 @@
 
 ssl_protocols TLSv1.2;
 ssl_ciphers EECDH+CHACHA20:EECDH+AES;
+ssl_ecdh_curve X25519:prime256v1:secp384r1:secp521r1;
 ssl_prefer_server_ciphers on;


### PR DESCRIPTION
prime256v1 (NIST P-256), secp384r1 (NIST P-384) and secp521r1 (NIST P-521) have been deemed insecure as per Daniel J. Bernstein's research (https://cr.yp.to/newelliptic/nistecc-20160106.pdf, https://safecurves.cr.yp.to/).

Despite that, the adoption of X25519 is too slim. Limiting to that curve would mean dropping compatibility with Safari, Edge and Internet Explorer.

This PR follows [Mozilla's Modern compatibility preset](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility) for TLS curves.