### PR TITLE
Add new TLS policy 'future'

### DIFF
--- a/h5bp/ssl/policy_future.conf
+++ b/h5bp/ssl/policy_future.conf
@@ -43,3 +43,4 @@ ssl_ecdh_curve X25519;
 
 # (2)
 #ssl_early_data on;
+

--- a/h5bp/ssl/policy_future.conf
+++ b/h5bp/ssl/policy_future.conf
@@ -5,32 +5,34 @@
 # For services that want to be on the bleeding edge, the parameters
 # below sacrifice compatibility for the highest level of security & performance
 #
-# (!) This policy enfore a strong SSL configuration, which may raise
-#     errors with old clients.
-#     If a more compatible profile is required, use intermediate policy.
+# (!) TLSv1.3 and it's 0-RTT feature require NGINX >=1.15.4 and OpenSSL >=1.1.1
+#     to be installed.
+#
+# (!) Don't enable `ssl_early_data` blindly! Requests sent within early data are
+#     subject to replay attacks.
 #
 # (1) The NIST curves (prime256v1, secp384r1, secp521r1) are known to be weak
-#      and potentially vulnerable.
+#     and potentially vulnerable.
 #
 #     Add them back to the parameter `ssl_ecdh_curve` below to support
 #     Microsoft Edge and Safari.
 #
 #     https://safecurves.cr.yp.to/
 #
-# (2) Supported by NGINX >=1.15.3. Enables TLS 1.3 0-RTT, allows for faster
-#     resumption of TLS sessions. Requests sent within early data are subject
-#     to replay attacks.
+# (2) Enables TLS 1.3 0-RTT, allows for faster resumption of TLS sessions.
 #
+# (!) Requests sent within early data are subject to replay attacks.
 #     To protect against such attacks at the application layer, the
 #     $ssl_early_data variable should be used:
 #       proxy_set_header Early-Data $ssl_early_data;
 #
-#     The application should return response code 425 for anything that could
-#     contain user supplied data.
+#     The application should return response code 425 for anything that
+#     could contain user supplied data.
 #
 #     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
 #
-# https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+# https://github.com/certbot/certbot/issues/6367
+# https://github.com/mozilla/server-side-tls/issues/217
 # https://nginx.org/en/docs/http/ngx_http_ssl_module.html
 
 ssl_protocols TLSv1.2 TLSv1.3;

--- a/h5bp/ssl/policy_future.conf
+++ b/h5bp/ssl/policy_future.conf
@@ -1,0 +1,43 @@
+# ----------------------------------------------------------------------
+# | SSL policy - Future                                                |
+# ----------------------------------------------------------------------
+
+# For services that want to be on the bleeding edge, the parameters
+# below sacrifice compatibility for the highest level of security & performance
+#
+# (!) This policy enfore a strong SSL configuration, which may raise
+#     errors with old clients.
+#     If a more compatible profile is required, use intermediate policy.
+#
+# (1) The NIST curves (prime256v1, secp384r1, secp521r1) are known to be weak
+#      and potentially vulnerable.
+#
+#     Add them back to the parameter `ssl_ecdh_curve` below to support
+#     Microsoft Edge and Safari.
+#
+#     https://safecurves.cr.yp.to/
+#
+# (2) Supported by NGINX >=1.15.3. Enables TLS 1.3 0-RTT, allows for faster
+#     resumption of TLS sessions. Requests sent within early data are subject
+#     to replay attacks.
+#
+#     To protect against such attacks at the application layer, the
+#     $ssl_early_data variable should be used:
+#       proxy_set_header Early-Data $ssl_early_data;
+#
+#     The application should return response code 425 for anything that could
+#     contain user supplied data.
+#
+#     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
+#
+# https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+# https://nginx.org/en/docs/http/ngx_http_ssl_module.html
+
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ciphers EECDH+CHACHA20:EECDH+AES;
+
+# (1)
+ssl_ecdh_curve X25519;
+
+# (2)
+#ssl_early_data on;

--- a/h5bp/ssl/policy_future.conf
+++ b/h5bp/ssl/policy_future.conf
@@ -43,4 +43,3 @@ ssl_ecdh_curve X25519;
 
 # (2)
 #ssl_early_data on;
-


### PR DESCRIPTION
TLSv1.3 has been available in the stable builds of NGINX and OpenSSL for a while now. Should be safe to turn on. Needs testing on latest stable/LTS releases of Debian and Ubuntu.