### PR TITLE
Use regexp in MIME-types based maps

### DIFF
--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -13,62 +13,62 @@
 # https://nginx.org/en/docs/http/ngx_http_headers_module.html#expires
 
 map $sent_http_content_type $expires {
-  default                                    1M;
+  default                                 1M;
 
   # CSS
-  ~*text/css\;?                              1y;
+  ~*text/css                              1y;
 
   # Data interchange
-  ~*application/atom+xml\;?                  1h;
-  ~*application/rdf+xml\;?                   1h;
-  ~*application/rss+xml\;?                   1h;
+  ~*application/atom+xml                  1h;
+  ~*application/rdf+xml                   1h;
+  ~*application/rss+xml                   1h;
 
-  ~*application/json\;?                      0;
-  ~*application/ld+json\;?                   0;
-  ~*application/schema+json\;?               0;
-  ~*application/geo+json\;?                  0;
-  ~*application/xml\;?                       0;
-  ~*text/calendar\;?                         0;
-  ~*text/xml\;?                              0;
+  ~*application/json                      0;
+  ~*application/ld+json                   0;
+  ~*application/schema+json               0;
+  ~*application/geo+json                  0;
+  ~*application/xml                       0;
+  ~*text/calendar                         0;
+  ~*text/xml                              0;
 
   # Favicon (cannot be renamed!) and cursor images
-  ~*image/vnd.microsoft.icon\;?              1w;
-  ~*image/x-icon\;?                          1w;
+  ~*image/vnd.microsoft.icon              1w;
+  ~*image/x-icon                          1w;
 
   # HTML
-  ~*text/html\;?                             0;
+  ~*text/html                             0;
 
   # JavaScript
-  ~*application/javascript\;?                1y;
-  ~*application/x-javascript\;?              1y;
-  ~*text/javascript\;?                       1y;
+  ~*application/javascript                1y;
+  ~*application/x-javascript              1y;
+  ~*text/javascript                       1y;
 
   # Manifest files
-  ~*application/manifest+json\;?             1w;
-  ~*application/x-web-app-manifest+json\;?   0;
-  ~*text/cache-manifest\;?                   0;
+  ~*application/manifest+json             1w;
+  ~*application/x-web-app-manifest+json   0;
+  ~*text/cache-manifest                   0;
 
   # Markdown
-  ~*text/markdown\;?                         0;
+  ~*text/markdown                         0;
 
   # Media files
-  ~*audio/.*                                 1M;
-  ~*image/.*                                 1M;
-  ~*video/.*                                 1M;
+  ~*audio/.*                              1M;
+  ~*image/.*                              1M;
+  ~*video/.*                              1M;
 
   # WebAssembly
-  ~*application/wasm\;?                      1y;
+  ~*application/wasm                      1y;
 
   # Web fonts
-  ~*font/.*                                  1M;
-  ~*application/vnd.ms-fontobject\;?         1M;
-  ~*application/x-font-ttf\;?                1M;
-  ~*application/x-font-woff\;?               1M;
-  ~*application/font-woff\;?                 1M;
-  ~*application/font-woff2\;?                1M;
+  ~*font/.*                               1M;
+  ~*application/vnd.ms-fontobject         1M;
+  ~*application/x-font-ttf                1M;
+  ~*application/x-font-woff               1M;
+  ~*application/font-woff                 1M;
+  ~*application/font-woff2                1M;
 
   # Other
-  ~*text/x-cross-domain-policy\;?            1w;
+  ~*text/x-cross-domain-policy            1w;
 }
 
 expires $expires;

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -13,7 +13,7 @@
 # https://nginx.org/en/docs/http/ngx_http_headers_module.html#expires
 
 map $sent_http_content_type $expires {
-  default                                     1M;
+  default                                    1M;
 
   # CSS
   ~*text/css\;?                              1y;

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -13,76 +13,62 @@
 # https://nginx.org/en/docs/http/ngx_http_headers_module.html#expires
 
 map $sent_http_content_type $expires {
-  default                               1M;
+  default                                     1M;
 
   # CSS
-  text/css                              1y;
+  ~*text/css\;?                              1y;
 
   # Data interchange
-  application/atom+xml                  1h;
-  application/rdf+xml                   1h;
-  application/rss+xml                   1h;
+  ~*application/atom+xml\;?                  1h;
+  ~*application/rdf+xml\;?                   1h;
+  ~*application/rss+xml\;?                   1h;
 
-  application/json                      0;
-  application/ld+json                   0;
-  application/schema+json               0;
-  application/geo+json                  0;
-  application/xml                       0;
-  text/calendar                         0;
-  text/xml                              0;
+  ~*application/json\;?                      0;
+  ~*application/ld+json\;?                   0;
+  ~*application/schema+json\;?               0;
+  ~*application/geo+json\;?                  0;
+  ~*application/xml\;?                       0;
+  ~*text/calendar\;?                         0;
+  ~*text/xml\;?                              0;
 
   # Favicon (cannot be renamed!) and cursor images
-  image/vnd.microsoft.icon              1w;
-  image/x-icon                          1w;
+  ~*image/vnd.microsoft.icon\;?              1w;
+  ~*image/x-icon\;?                          1w;
 
   # HTML
-  text/html                             0;
+  ~*text/html\;?                             0;
 
   # JavaScript
-  application/javascript                1y;
-  application/x-javascript              1y;
-  text/javascript                       1y;
+  ~*application/javascript\;?                1y;
+  ~*application/x-javascript\;?              1y;
+  ~*text/javascript\;?                       1y;
 
   # Manifest files
-  application/manifest+json             1w;
-  application/x-web-app-manifest+json   0;
-  text/cache-manifest                   0;
-
+  ~*application/manifest+json\;?             1w;
+  ~*application/x-web-app-manifest+json\;?   0;
+  ~*text/cache-manifest\;?                   0;
 
   # Markdown
-  text/markdown                         0;
+  ~*text/markdown\;?                         0;
 
   # Media files
-  audio/ogg                             1M;
-  image/bmp                             1M;
-  image/gif                             1M;
-  image/jpeg                            1M;
-  image/png                             1M;
-  image/svg+xml                         1M;
-  image/webp                            1M;
-  video/mp4                             1M;
-  video/ogg                             1M;
-  video/webm                            1M;
+  ~*audio/.*                                 1M;
+  ~*image/.*                                 1M;
+  ~*video/.*                                 1M;
 
   # WebAssembly
-  application/wasm                      1y;
+  ~*application/wasm\;?                      1y;
 
   # Web fonts
-  font/collection                       1M;
-  application/vnd.ms-fontobject         1M;
-  font/eot                              1M;
-  font/opentype                         1M;
-  font/otf                              1M;
-  application/x-font-ttf                1M;
-  font/ttf                              1M;
-  application/font-woff                 1M;
-  application/x-font-woff               1M;
-  font/woff                             1M;
-  application/font-woff2                1M;
-  font/woff2                            1M;
+  ~*font/.*                                  1M;
+  ~*application/vnd.ms-fontobject\;?         1M;
+  ~*application/x-font-ttf\;?                1M;
+  ~*application/x-font-woff\;?               1M;
+  ~*application/font-woff\;?                 1M;
+  ~*application/font-woff2\;?                1M;
 
   # Other
-  text/x-cross-domain-policy            1w;
+  ~*text/x-cross-domain-policy\;?            1w;
 }
 
 expires $expires;


### PR DESCRIPTION
Switched to using regular expressions.

Since we're already using regular expressions, I also simplified the media file and web font mapping.

Fix #220