### PR TITLE
Docs formatting, some list reordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This repository has the following structure:
 
   * **`templates` folder**
 
-    Files in this folder contain a `server{}` template for secure and non-secure hosts.
+    Files in this folder contain a `server` template for secure and non-secure hosts.
     They are intended to be copied in the `conf.d` folder with all `example.com` 
     occurrences changed to the target host.
 

--- a/conf.d/.default.conf
+++ b/conf.d/.default.conf
@@ -7,7 +7,7 @@
 # If no default server is defined, Nginx will use the first found server.
 # To prevent host header attacks, or other potential problems when an unknown
 # servername is used in a request, it's recommended to drop the request
-# returning 444 "no response".
+# returning 444 "No Response".
 
 server {
   listen [::]:443 ssl http2 default_server;

--- a/conf.d/no-ssl.default.conf
+++ b/conf.d/no-ssl.default.conf
@@ -6,8 +6,8 @@
 #
 # If no default server is defined, Nginx will use the first found server.
 # To prevent host header attacks, or other potential problems when an unknown
-# servername is used in a request, it's recommended to drop the request
-# returning 444 "no response".
+# `server_name` is used in a request, it's recommended to drop the request
+# returning 444 "No Response".
 #
 # (1) In production, only secure hosts should be used (all `no-ssl` disabled).
 #     If so, redirect first ANY request to a secure connexion before handling it

--- a/conf.d/no-ssl.default.conf
+++ b/conf.d/no-ssl.default.conf
@@ -6,12 +6,12 @@
 #
 # If no default server is defined, Nginx will use the first found server.
 # To prevent host header attacks, or other potential problems when an unknown
-# `server_name` is used in a request, it's recommended to drop the request
+# server name is used in a request, it's recommended to drop the request
 # returning 444 "No Response".
 #
 # (1) In production, only secure hosts should be used (all `no-ssl` disabled).
-#     If so, redirect first ANY request to a secure connexion before handling it
-#     even if the host is unknown.
+#     If so, redirect first ANY request to a secure connection before handling
+#     it, even if the host is unknown.
 #
 #     https://observatory.mozilla.org/faq/
 

--- a/h5bp/cross-origin/requests.conf
+++ b/h5bp/cross-origin/requests.conf
@@ -13,7 +13,7 @@
 #
 # Instead of using this file, consider using a specific rule such as:
 #
-# Allow access based on [sub]domain:
-#    add_header Access-Control-Allow-Origin "subdomain.example.com";
+#   Allow access based on [sub]domain:
+#      add_header Access-Control-Allow-Origin "subdomain.example.com";
 
 add_header Access-Control-Allow-Origin $cors;

--- a/h5bp/cross-origin/resource_timing.conf
+++ b/h5bp/cross-origin/resource_timing.conf
@@ -4,10 +4,9 @@
 
 # Allow cross-origin access to the timing information for all resources.
 #
-# If a resource isn't served with a `Timing-Allow-Origin` header that
-# would allow its timing information to be shared with the document,
-# some of the attributes of the `PerformanceResourceTiming` object will
-# be set to zero.
+# If a resource isn't served with a `Timing-Allow-Origin` header that would
+# allow its timing information to be shared with the document, some of the
+# attributes of the `PerformanceResourceTiming` object will be set to zero.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin
 # https://www.w3.org/TR/resource-timing/

--- a/h5bp/internet_explorer/x-ua-compatible.conf
+++ b/h5bp/internet_explorer/x-ua-compatible.conf
@@ -9,8 +9,8 @@
 #
 # (!) Starting with Internet Explorer 11, document modes are deprecated.
 # If your business still relies on older web apps and services that were
-# designed for older versions of Internet Explorer, you might want to
-# consider enabling `Enterprise Mode` throughout your company.
+# designed for older versions of Internet Explorer, you might want to consider
+# enabling `Enterprise Mode` throughout your company.
 #
 # https://msdn.microsoft.com/en-us/library/ie/bg182625.aspx#docmode
 # https://blogs.msdn.microsoft.com/ie/2014/04/02/stay-up-to-date-with-enterprise-mode-for-internet-explorer-11/

--- a/h5bp/location/security_file_access.conf
+++ b/h5bp/location/security_file_access.conf
@@ -2,17 +2,17 @@
 # | File access                                                        |
 # ----------------------------------------------------------------------
 
-# Block access to all hidden files and directories with the exception of
-# the visible content from within the `/.well-known/` hidden directory.
+# Block access to all hidden files and directories with the exception of the
+# visible content from within the `/.well-known/` hidden directory.
 #
-# These types of files usually contain user preferences or the preserved
-# state of a utility, and can include rather private places like, for
-# example, the `.git` or `.svn` directories.
+# These types of files usually contain user preferences or the preserved state
+# of a utility, and can include rather private places like, for example, the
+# `.git` or `.svn` directories.
 #
-# The `/.well-known/` directory represents the standard (RFC 5785) path
-# prefix for "well-known locations" (e.g.: `/.well-known/manifest.json`,
-# `/.well-known/keybase.txt`), and therefore, access to its visible
-# content should not be blocked.
+# The `/.well-known/` directory represents the standard (RFC 5785) path prefix
+# for "well-known locations" (e.g.: `/.well-known/manifest.json`,
+# `/.well-known/keybase.txt`), and therefore, access to its visible content
+# should not be blocked.
 #
 # https://www.mnot.net/blog/2010/04/07/well-known
 # https://tools.ietf.org/html/rfc5785
@@ -25,17 +25,16 @@ location ~* /\.(?!well-known\/) {
 
 # Block access to files that can expose sensitive information.
 #
-# By default, block access to backup and source files that may be
-# left by some text editors and can pose a security risk when anyone
-# has access to them.
+# By default, block access to backup and source files that may be left by some
+# text editors and can pose a security risk when anyone has access to them.
 #
 # https://feross.org/cmsploit/
 #
-# (!) Update the `location` regular expression from below to
-# include any files that might end up on your production server and
-# can expose sensitive information about your website. These files may
-# include: configuration files, files that contain metadata about the
-# project (e.g.: project dependencies), build scripts, etc..
+# (!) Update the `location` regular expression from below to include any files
+# that might end up on your production server and can expose sensitive
+# information about your website. These files may include: configuration files,
+# files that contain metadata about the project (e.g.: project dependencies),
+# build scripts, etc..
 
 location ~* (?:#.*#|\.(?:bak|conf|dist|fla|in[ci]|log|orig|psd|sh|sql|sw[op])|~)$ {
   deny all;

--- a/h5bp/location/web_performance_filename-based_cache_busting.conf
+++ b/h5bp/location/web_performance_filename-based_cache_busting.conf
@@ -2,11 +2,11 @@
 # | Filename-based cache busting                                       |
 # ----------------------------------------------------------------------
 
-# If you're not using a build process to manage your filename version
-# revving, you might want to consider enabling the following directives
+# If you're not using a build process to manage your filename version revving,
+# you might want to consider enabling the following directives.
 #
-# To understand why this is important and even a better solution than
-# using something like `*.css?v231`, please see:
+# To understand why this is important and even a better solution than using
+# something like `*.css?v231`, please see:
 # https://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/
 
 location ~* (.+)\.(?:\w+)\.(bmp|css|cur|gif|ico|jpe?g|m?js|png|svgz?|webp|webmanifest)$ {

--- a/h5bp/media_types/character_encodings.conf
+++ b/h5bp/media_types/character_encodings.conf
@@ -2,8 +2,8 @@
 # | Character encodings                                                |
 # ----------------------------------------------------------------------
 
-# Serve all resources labeled as `text/html` or `text/plain`
-# with the media type `charset` parameter set to `UTF-8`.
+# Serve all resources labeled as `text/html` or `text/plain` with the media type
+# `charset` parameter set to `UTF-8`.
 #
 # https://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
 
@@ -12,7 +12,7 @@ charset utf-8;
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 # Update charset_types to match updated mime.types.
-# text/html is always included by charset module.
+# `text/html` is always included by charset module.
 # Default: text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml
 #
 # https://nginx.org/en/docs/http/ngx_http_charset_module.html#charset_types

--- a/h5bp/security/content-security-policy.conf
+++ b/h5bp/security/content-security-policy.conf
@@ -5,12 +5,11 @@
 # Mitigate the risk of cross-site scripting and other content-injection
 # attacks.
 #
-# This can be done by setting a `Content Security Policy` which
-# whitelists trusted sources of content for your website.
+# This can be done by setting a `Content Security Policy` which whitelists
+# trusted sources of content for your website.
 #
-# There is no policy that fits all websites, you will have to modify
-# the `Content-Security-Policy` directives in the example depending
-# on your needs.
+# There is no policy that fits all websites, you will have to modify the
+# `Content-Security-Policy` directives in the example depending on your needs.
 #
 # To make your CSP implementation easier, you can use an online CSP header
 # generator such as:

--- a/h5bp/security/referrer-policy.conf
+++ b/h5bp/security/referrer-policy.conf
@@ -3,14 +3,14 @@
 # ----------------------------------------------------------------------
 
 # A web application uses HTTPS and a URL-based session identifier.
-# The web application might wish to link to HTTPS resources on other
-# web sites without leaking the user's session identifier in the URL.
+# The web application might wish to link to HTTPS resources on other web
+# sites without leaking the user's session identifier in the URL.
 #
-# This can be done by setting a `Referrer Policy` which
-# whitelists trusted sources of content for your website.
+# This can be done by setting a `Referrer Policy` which whitelists trusted
+# sources of content for your website.
 #
-# To check your referrer policy, you can use an online service
-# such as: https://securityheaders.io/.
+# To check your referrer policy, you can use an online service such as:
+# https://securityheaders.io/.
 #
 # https://scotthelme.co.uk/a-new-security-header-referrer-policy/
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

--- a/h5bp/security/server_software_information.conf
+++ b/h5bp/security/server_software_information.conf
@@ -2,8 +2,7 @@
 # | Server software information                                        |
 # ----------------------------------------------------------------------
 
-# Prevent Nginx from sending in the `Server` response header its
-# exact version number.
+# Prevent Nginx from sending its version number in the "Server" response header.
 #
 # https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens
 

--- a/h5bp/security/strict-transport-security.conf
+++ b/h5bp/security/strict-transport-security.conf
@@ -4,14 +4,13 @@
 
 # Force client-side SSL redirection.
 #
-# If a user types `example.com` in their browser, even if the server
-# redirects them to the secure version of the website, that still leaves
-# a window of opportunity (the initial HTTP connection) for an attacker
-# to downgrade or redirect the request.
+# If a user types `example.com` in their browser, even if the server redirects
+# them to the secure version of the website, that still leaves a window of
+# opportunity (the initial HTTP connection) for an attacker to downgrade or
+# redirect the request.
 #
-# The following header ensures that browser will ONLY connect to your
-# server via HTTPS, regardless of what the users type in the browser's
-# address bar.
+# The following header ensures that browser will ONLY connect to your server
+# via HTTPS, regardless of what the users type in the browser's address bar.
 #
 # (!) Be aware that this, once published, is not revokable and you must ensure
 # being able to serve the site via SSL for the duration you've specified
@@ -25,9 +24,11 @@
 # (1) If you want to submit your site for HSTS preload (2) you must
 #     * ensure the `includeSubDomains` directive to be present
 #     * the `preload` directive to be specified
-#     * the `max-age` to be at least 31536000 seconds (1 year) according to the current status.
+#     * the `max-age` to be at least 31536000 seconds (1 year) according to the
+#       current status.
 #
-#     It is also advised (3) to only serve the HSTS header via a secure connection.
+#     It is also advised (3) to only serve the HSTS header via a secure
+#     connection.
 #
 # (2) https://hstspreload.org/
 # (3) https://tools.ietf.org/html/rfc6797#section-7.2

--- a/h5bp/security/x-content-type-options.conf
+++ b/h5bp/security/x-content-type-options.conf
@@ -4,10 +4,10 @@
 
 # Prevent some browsers from MIME-sniffing the response.
 #
-# This reduces exposure to drive-by download attacks and cross-origin
-# data leaks, and should be left uncommented, especially if the server
-# is serving user-uploaded content or content that could potentially be
-# treated as executable by the browser.
+# This reduces exposure to drive-by download attacks and cross-origin data
+# leaks, and should be left uncommented, especially if the server is serving
+# user-uploaded content or content that could potentially be treated as
+# executable by the browser.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
 # https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-v-comprehensive-protection/

--- a/h5bp/security/x-frame-options.conf
+++ b/h5bp/security/x-frame-options.conf
@@ -4,28 +4,27 @@
 
 # Protect website against clickjacking.
 #
-# The example below sends the `X-Frame-Options` response header with
-# the value `DENY`, informing browsers not to display the content of
-# the web page in any frame.
+# The example below sends the `X-Frame-Options` response header with the value
+# `DENY`, informing browsers not to display the content of the web page in any
+# frame.
 #
-# This might not be the best setting for everyone. You should read
-# about the other two possible values the `X-Frame-Options` header
-# field can have: `SAMEORIGIN` and `ALLOW-FROM`.
+# This might not be the best setting for everyone. You should read about the
+# other two possible values the `X-Frame-Options` header field can have:
+# `SAMEORIGIN` and `ALLOW-FROM`.
 # https://tools.ietf.org/html/rfc7034#section-2.1.
 #
-# Keep in mind that while you could send the `X-Frame-Options` header
-# for all of your website’s pages, this has the potential downside that
-# it forbids even non-malicious framing of your content (e.g.: when
-# users visit your website using a Google Image Search results page).
+# Keep in mind that while you could send the `X-Frame-Options` header for all
+# of your website’s pages, this has the potential downside that it forbids even
+# non-malicious framing of your content (e.g.: when users visit your website
+# using a Google Image Search results page).
 #
-# Nonetheless, you should ensure that you send the `X-Frame-Options`
-# header for all pages that allow a user to make a state-changing
-# operation (e.g: pages that contain one-click purchase links, checkout
-# or bank-transfer confirmation pages, pages that make permanent
-# configuration changes, etc.).
+# Nonetheless, you should ensure that you send the `X-Frame-Options` header for
+# all pages that allow a user to make a state-changing operation (e.g: pages
+# that contain one-click purchase links, checkout or bank-transfer confirmation
+# pages, pages that make permanent configuration changes, etc.).
 #
-# Sending the `X-Frame-Options` header can also protect your website
-# against more than just clickjacking attacks:
+# Sending the `X-Frame-Options` header can also protect your website against
+# more than just clickjacking attacks.
 # https://cure53.de/xfo-clickjacking.pdf.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

--- a/h5bp/security/x-xss-protection.conf
+++ b/h5bp/security/x-xss-protection.conf
@@ -2,33 +2,31 @@
 # | Reflected Cross-Site Scripting (XSS) attacks                       |
 # ----------------------------------------------------------------------
 
-# (1) Try to re-enable the cross-site scripting (XSS) filter built
-#     into most web browsers.
+# (1) Try to re-enable the cross-site scripting (XSS) filter built into most
+#     web browsers.
 #
-#     The filter is usually enabled by default, but in some cases it
-#     may be disabled by the user. However, in Internet Explorer for
-#     example, it can be re-enabled just by sending the
-#     `X-XSS-Protection` header with the value of `1`.
+#     The filter is usually enabled by default, but in some cases it may be
+#     disabled by the user. However, in Internet Explorer for example, it can be
+#     re-enabled just by sending the  `X-XSS-Protection` header with the value
+#     of `1`.
 #
-# (2) Prevent web browsers from rendering the web page if a potential
-#     reflected (a.k.a non-persistent) XSS attack is detected by the
-#     filter.
+# (2) Prevent web browsers from rendering the web page if a potential reflected
+#     (a.k.a non-persistent) XSS attack is detected by the filter.
 #
-#     By default, if the filter is enabled and browsers detect a
-#     reflected XSS attack, they will attempt to block the attack
-#     by making the smallest possible modifications to the returned
-#     web page.
+#     By default, if the filter is enabled and browsers detect a reflected XSS
+#     attack, they will attempt to block the attack by making the smallest
+#     possible modifications to the returned web page.
 #
-#     Unfortunately, in some browsers (e.g.: Internet Explorer),
-#     this default behavior may allow the XSS filter to be exploited,
-#     thereby, it's better to inform browsers to prevent the rendering
-#     of the page altogether, instead of attempting to modify it.
+#     Unfortunately, in some browsers (e.g.: Internet Explorer), this default
+#     behavior may allow the XSS filter to be exploited. Therefore, it's better
+#     to inform browsers to prevent the rendering of the page altogether,
+#     instead of attempting to modify it.
 #
 #     https://hackademix.net/2009/11/21/ies-xss-filter-creates-xss-vulnerabilities
 #
-# (!) Do not rely on the XSS filter to prevent XSS attacks! Ensure that
-#     you are taking all possible measures to prevent XSS attacks, the
-#     most obvious being: validating and sanitizing your website's inputs.
+# (!) Do not rely on the XSS filter to prevent XSS attacks! Ensure that you are
+#     taking all possible measures to prevent XSS attacks, the most obvious
+#     being: validating and sanitizing your website's inputs.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
 # https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-iv-the-xss-filter/

--- a/h5bp/ssl/certificate_files.conf
+++ b/h5bp/ssl/certificate_files.conf
@@ -2,8 +2,8 @@
 # | Certificate files                                                  |
 # ----------------------------------------------------------------------
 
-# This default SSL certificate will be served whenever the client lacks
-# support for SNI (Server Name Indication).
+# This default SSL certificate will be served whenever the client lacks support
+# for SNI (Server Name Indication).
 # Make it a symlink to the most important certificate you have, so that
 # users of IE 8 and below on WinXP can see your main site without SSL errors.
 #

--- a/h5bp/ssl/ocsp_stapling.conf
+++ b/h5bp/ssl/ocsp_stapling.conf
@@ -2,10 +2,10 @@
 # | Online Certificate Status Protocol stapling                        |
 # ----------------------------------------------------------------------
 
-# OCSP is a lightweight, only one record to help clients verify the
-# validity of the server certificate.
-# OCSP stapling allows the server to send its cached OCSP record during
-# the TLS handshake, without the need of 3rd party OCSP responder.
+# OCSP is a lightweight, only one record to help clients verify the validity of
+# the server certificate.
+# OCSP stapling allows the server to send its cached OCSP record during the TLS
+# handshake, without the need of 3rd party OCSP responder.
 #
 # https://wiki.mozilla.org/Security/Server_Side_TLS#OCSP_Stapling
 # https://tools.ietf.org/html/rfc6066#section-8
@@ -29,6 +29,6 @@ resolver
   # (2)
   8.8.8.8 8.8.4.4 [2001:4860:4860::8888] [2001:4860:4860::8844]
   # (3)
-  # 216.146.35.35 216.146.36.36 
+  # 216.146.35.35 216.146.36.36
   valid=60s;
 resolver_timeout 2s;

--- a/h5bp/ssl/policy_deprecated.conf
+++ b/h5bp/ssl/policy_deprecated.conf
@@ -2,13 +2,13 @@
 # | SSL policy - Deprecated                                            |
 # ----------------------------------------------------------------------
 
-# For services that don't need compatibility with legacy clients
-# (mostly WinXP), but still need to support a wide range of clients,
-# this configuration is recommended.
+# For services that don't need compatibility with legacy clients (mostly WinXP),
+# but still need to support a wide range of clients, this configuration is
+# recommended.
 #
 # Protect against the BEAST and POODLE attacks by not using SSLv3 at all.
-# If you need to support older browsers (IE6) you may need to add
-# SSLv3 to the list of protocols.
+# If you need to support older browsers (IE6) you may need to add SSLv3 to the
+# list of protocols.
 #
 # Based on intermediate profile recommended by Mozilla.
 # https://mozilla.github.io/server-side-tls/ssl-config-generator/

--- a/h5bp/ssl/policy_intermediate.conf
+++ b/h5bp/ssl/policy_intermediate.conf
@@ -2,16 +2,16 @@
 # | SSL policy - Intermediate                                          |
 # ----------------------------------------------------------------------
 
-# For services that don't need backward compatibility, the parameters
-# below provide a higher level of security.
+# For services that don't need backward compatibility, the parameters below
+# provide a higher level of security.
 #
-# (!) This policy enfore a strong SSL configuration, which may raise
-#     errors with old clients.
+# (!) This policy enforces a strong SSL configuration, which may raise errors
+#     with old clients.
 #     If a more compatible profile is required, use intermediate policy.
 #
-# (1) The NIST curves (prime256v1, secp384r1, secp521r1) are known
-#     to be weak and potentially vulnerable but are required to support
-#     Microsoft Edge and Safari.
+# (1) The NIST curves (prime256v1, secp384r1, secp521r1) are known to be weak
+#     and potentially vulnerable but are required to support Microsoft Edge
+#     and Safari.
 #     https://safecurves.cr.yp.to/
 #
 # https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations

--- a/h5bp/ssl/policy_modern.conf
+++ b/h5bp/ssl/policy_modern.conf
@@ -26,7 +26,7 @@
 #     $ssl_early_data variable should be used:
 #       proxy_set_header Early-Data $ssl_early_data;
 #
-#     The application should return response code 425 ("Too Early") for anything
+#     The application should return response code 425 "Too Early" for anything
 #     that could contain user supplied data.
 #
 #     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425

--- a/h5bp/ssl/policy_modern.conf
+++ b/h5bp/ssl/policy_modern.conf
@@ -2,8 +2,8 @@
 # | SSL policy - Modern                                                |
 # ----------------------------------------------------------------------
 
-# For services that want to be on the bleeding edge, the parameters
-# below sacrifice compatibility for the highest level of security & performance
+# For services that want to be on the bleeding edge, the parameters below
+# sacrifice compatibility for the highest level of security & performance
 #
 # (!) TLSv1.3 and it's 0-RTT feature require NGINX >=1.15.4 and OpenSSL >=1.1.1
 #     to be installed.
@@ -26,8 +26,8 @@
 #     $ssl_early_data variable should be used:
 #       proxy_set_header Early-Data $ssl_early_data;
 #
-#     The application should return response code 425 for anything that
-#     could contain user supplied data.
+#     The application should return response code 425 ("Too Early") for anything
+#     that could contain user supplied data.
 #
 #     https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
 #

--- a/h5bp/ssl/ssl_engine.conf
+++ b/h5bp/ssl/ssl_engine.conf
@@ -13,14 +13,14 @@
 #     Default is 75s
 #
 # (3) SSL buffer size
-#     Set 1400 bytes to fit in one MTU
+#     Set 1400 bytes to fit in one MTU.
 #     https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_buffer_size
 #
 # (4) Disable session tickets
-#     Session tickets keys are not auto-rotated. Only a HUP / restart
-#     will do so and when a restart is performed the previous key is
-#     lost, which resets all previous sessions.
-#     Only enable session tickets if you setup a manual rotation mechanism.
+#     Session tickets keys are not auto-rotated. Only a HUP / restart will do
+#     so and when a restart is performed the previous key is lost, which resets
+#     all previous sessions.
+#     Only enable session tickets if you set up a manual rotation mechanism.
 #     https://trac.nginx.org/nginx/changeset/1356a3b9692441e163b4e78be4e9f5a46c7479e9/nginx
 #     https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets
 #

--- a/h5bp/web_performance/cache-file-descriptors.conf
+++ b/h5bp/web_performance/cache-file-descriptors.conf
@@ -2,29 +2,29 @@
 # | Cache file-descriptors                                             |
 # ----------------------------------------------------------------------
 
-# This tells Nginx to cache open file handles, "not found" errors and
+# This tells Nginx to cache open file handles, "Not Found" errors and
 # metadata about files and their permissions.
 #
-# Based on these cached metadata, Nginx can immediately begin sending
-# data when a popular file is requested, and will also know to
-# immediately send a 404 if a file is missing on disk, and so on.
+# Based on these cached metadata, Nginx can immediately begin sending data when
+# a popular file is requested, and will also know to immediately send a 404 if a
+# file is missing on disk, and so on.
 #
-# (!) It also means that the server won't react immediately to changes
-#     on disk, which may be undesirable.
-#     As only metadata are cached, edited files may be truncated until
-#     the cache is refreshed.
+# (!) It also means that the server won't react immediately to changes on disk,
+#     which may be undesirable.
+#     As only metadata are cached, edited files may be truncated until the cache
+#     is refreshed.
 #     https://github.com/h5bp/server-configs-nginx/issues/203
 #
-# In the below configuration, inactive files are released from the cache
-# after 20 seconds, whereas active (recently requested) files are
-# re-validated every 30 seconds.
-# Descriptors will not be cached unless they are used at least 2 times
-# within 20 seconds (the inactive time).
-# A maximum of the 1000 most recently used file descriptors can be
-# cached at any time.
+# In the below configuration, inactive files are released from the cache after
+# 20 seconds, whereas active (recently requested) files are re-validated every
+# 30 seconds.
+# Descriptors will not be cached unless they are used at least 2 times within
+# 20 seconds (the inactive time).
+# A maximum of the 1000 most recently used file descriptors can be cached at
+# any time.
 #
-# Production servers with stable file collections will definitely want
-# to enable the cache.
+# Production servers with stable file collections will definitely want to enable
+# the cache.
 #
 # https://nginx.org/en/docs/http/ngx_http_core_module.html#open_file_cache
 

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -4,9 +4,8 @@
 
 # Serve resources with far-future expiration date.
 #
-# (!) If you don't control versioning with filename-based
-# cache busting, you should consider lowering the cache times
-# to something like one week.
+# (!) If you don't control versioning with filename-based cache busting, you
+# should consider lowering the cache times to something like one week.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires

--- a/h5bp/web_performance/compression.conf
+++ b/h5bp/web_performance/compression.conf
@@ -9,14 +9,14 @@
 gzip on;
 
 # Compression level (1-9).
-# 5 is a perfect compromise between size and CPU usage, offering about
-# 75% reduction for most ASCII files (almost identical to level 9).
+# 5 is a perfect compromise between size and CPU usage, offering about 75%
+# reduction for most ASCII files (almost identical to level 9).
 # Default: 1
 gzip_comp_level 5;
 
-# Don't compress anything that's already small and unlikely to shrink much
-# if at all (the default is 20 bytes, which is bad as that usually leads to
-# larger files after gzipping).
+# Don't compress anything that's already small and unlikely to shrink much if at
+# all (the default is 20 bytes, which is bad as that usually leads to larger
+# files after gzipping).
 # Default: 20
 gzip_min_length 256;
 
@@ -33,39 +33,39 @@ gzip_proxied any;
 gzip_vary on;
 
 # Compress all output labeled with one of the following MIME-types.
-# text/html is always compressed by gzip module.
+# `text/html` is always compressed by gzip module.
 # Default: text/html
 gzip_types
   application/atom+xml
+  application/geo+json
   application/javascript
   application/json
   application/ld+json
   application/manifest+json
+  application/rdf+xml
   application/rss+xml
-  application/geo+json
   application/vnd.ms-fontobject
+  application/wasm
   application/x-web-app-manifest+json
   application/xhtml+xml
   application/xml
-  application/rdf+xml
   font/otf
-  application/wasm
   image/bmp
   image/svg+xml
   text/cache-manifest
+  text/calendar
   text/css
   text/javascript
-  text/plain
   text/markdown
+  text/plain
   text/vcard
-  text/calendar
   text/vnd.rim.location.xloc
   text/vtt
   text/x-component
   text/x-cross-domain-policy;
 
-# This should be turned on if you are going to have pre-compressed copies (.gz) of
-# static files available. If not it should be left off as it will cause extra I/O
-# for the check. It is best if you enable this in a location{} block for
-# a specific directory, or on an individual server{} level.
+# This should be turned on if you are going to have pre-compressed copies (.gz)
+# of static files available. If not it should be left off as it will cause extra
+# I/O for the check. It is best if you enable this in a location{} block for a
+# specific directory, or on an individual `server` level.
 # gzip_static on;

--- a/h5bp/web_performance/no-transform.conf
+++ b/h5bp/web_performance/no-transform.conf
@@ -2,16 +2,15 @@
 # | Content transformation                                             |
 # ----------------------------------------------------------------------
 
-# Prevent intermediate caches or proxies (e.g.: such as the ones
-# used by mobile network providers) from modifying the website's
-# content.
+# Prevent intermediate caches or proxies (e.g.: such as the ones used by some
+# mobile network providers) from modifying the website's content.
 #
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 # https://tools.ietf.org/html/rfc2616#section-14.9.5
 #
-# (!) If you are using `ngx_pagespeed`, please note that setting
-# the `Cache-Control: no-transform` response header will prevent
-# `PageSpeed` from rewriting `HTML` files, and, if the
+# (!) If you are using `ngx_pagespeed`, please note that setting the
+# `Cache-Control: no-transform` response header will prevent PageSpeed from
+# rewriting `HTML` files, and, if the
 # `pagespeed DisableRewriteOnNoTransform off` directive isn't used,
 # also from rewriting other resources.
 #

--- a/mime.types
+++ b/mime.types
@@ -122,6 +122,7 @@ types {
     application/xhtml+xml                 xhtml;
     application/xslt+xml                  xsl;
     application/zip                       zip;
+    text/calendar                         ics;
     text/css                              css;
     text/csv                              csv;
     text/html                             htm html shtml;
@@ -129,7 +130,6 @@ types {
     text/mathml                           mml;
     text/plain                            txt;
     text/vcard                            vcard vcf;
-    text/calendar                         ics;
     text/vnd.rim.location.xloc            xloc;
     text/vnd.sun.j2me.app-descriptor      jad;
     text/vnd.wap.wml                      wml;

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,8 +7,8 @@
 # https://en.wikipedia.org/wiki/Principle_of_least_privilege
 user www-data;
 
-# Sets the worker threads to the number of CPU cores available in the system for best performance.
-# Should be > the number of CPU cores.
+# Sets the worker threads to the number of CPU cores available in the system for
+# best performance. Should be > the number of CPU cores.
 # Maximum number of connections = worker_processes * worker_connections
 # Default: 1
 # https://nginx.org/en/docs/ngx_core_module.html#worker_processes
@@ -20,13 +20,14 @@ worker_processes auto;
 # https://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
 worker_rlimit_nofile 8192;
 
-# Provides the configuration file context in which the directives
-# that affect connection processing are specified.
+# Provides the configuration file context in which the directives that affect
+# connection processing are specified.
 # https://nginx.org/en/docs/ngx_core_module.html#events
 events {
 
   # If you need more connections than this, you start optimizing your OS.
-  # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
+  # That's probably the point at which you hire people who are smarter than you
+  # as this is *a lot* of requests.
   # Should be < worker_rlimit_nofile.
   # Default: 512
   # https://nginx.org/en/docs/ngx_core_module.html#worker_connections
@@ -35,7 +36,7 @@ events {
 }
 
 # Log errors and warnings to this file
-# This is only used when you don't override it on a server{} level
+# This is only used when you don't override it on a `server` level
 # Default: logs/error.log error
 # https://nginx.org/en/docs/ngx_core_module.html#error_log
 error_log /var/log/nginx/error.log warn;
@@ -47,10 +48,10 @@ pid /var/run/nginx.pid;
 
 http {
 
-  # Hide nginx version information.
+  # Hide Nginx version information.
   include h5bp/security/server_software_information.conf;
 
-  # Specify MIME types for files.
+  # Specify media (MIME) types for files.
   include h5bp/media_types/media_types.conf;
 
   # Set character encodings.
@@ -63,7 +64,7 @@ http {
                     '"$http_user_agent" "$http_x_forwarded_for"';
 
   # Log access to this file
-  # This is only used when you don't override it on a server{} level
+  # This is only used when you don't override it on a `server` level
   # Default: logs/access.log combined
   # https://nginx.org/en/docs/http/ngx_http_log_module.html#access_log
   access_log /var/log/nginx/access.log main;
@@ -75,17 +76,16 @@ http {
   # https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout
   keepalive_timeout 20s;
 
-  # Speed up file transfers by using sendfile() to copy directly
-  # between descriptors rather than using read()/write().
-  # For performance reasons, on FreeBSD systems w/ ZFS
-  # this option should be disabled as ZFS's ARC caches
-  # frequently used files in RAM by default.
+  # Speed up file transfers by using `sendfile()` to copy directly between
+  # descriptors rather than using `read()`/`write()``.
+  # For performance reasons, on FreeBSD systems w/ ZFS this option should be
+  # disabled as ZFS's ARC caches frequently used files in RAM by default.
   # Default: off
   # https://nginx.org/en/docs/http/ngx_http_core_module.html#sendfile
   sendfile on;
 
-  # Don't send out partial frames; this increases throughput
-  # since TCP frames are filled up before being sent out.
+  # Don't send out partial frames; this increases throughput since TCP frames
+  # are filled up before being sent out.
   # Default: off
   # https://nginx.org/en/docs/http/ngx_http_core_module.html#tcp_nopush
   tcp_nopush on;
@@ -143,7 +143,7 @@ http {
   }
 
   # Include files in the conf.d folder.
-  # server{} configuration files should be placed in the conf.d folder.
+  # `server` configuration files should be placed in the conf.d folder.
   # The configurations should be disabled by prefixing files with a dot.
   include conf.d/*.conf;
 


### PR DESCRIPTION
Docs formatting and presentation to max 80 characters with no widowed words.

No new code,  no removals. Some minor reordering on config arrays (e.g. media types) to be alphabetical, but only where it's clear they _want_ to be alphabetical.