### PR TITLE
Switch tertiary DNS used for OCSP checking to OpenDNS

### DIFF
--- a/h5bp/ssl/ocsp_stapling.conf
+++ b/h5bp/ssl/ocsp_stapling.conf
@@ -17,8 +17,8 @@
 # (2) Use Google 8.8.8.8 DNS resolver
 #     https://developers.google.com/speed/public-dns/docs/using
 #
-# (3) Use Dyn DNS resolver
-#     https://help.dyn.com/internet-guide-setup/
+# (3) Use OpenDNS resolver
+#     https://use.opendns.com
 
 ssl_stapling on;
 ssl_stapling_verify on;
@@ -29,6 +29,6 @@ resolver
   # (2)
   8.8.8.8 8.8.4.4 [2001:4860:4860::8888] [2001:4860:4860::8844]
   # (3)
-  # 216.146.35.35 216.146.36.36
+  # 208.67.222.222 208.67.220.220 [2620:119:35::35] [2620:119:53::53]
   valid=60s;
 resolver_timeout 2s;


### PR DESCRIPTION
Oracle is shutting down Dyn DNS in 2020.

This PR switches tertiary DNS used for OCSP checking to OpenDNS, with IPv4 and IPv6 flavours.