### PR TITLE
Do no use non-ASCII characters in loaded configs

### DIFF
--- a/h5bp/security/x-frame-options.conf
+++ b/h5bp/security/x-frame-options.conf
@@ -14,7 +14,7 @@
 # https://tools.ietf.org/html/rfc7034#section-2.1.
 #
 # Keep in mind that while you could send the `X-Frame-Options` header for all
-# of your website’s pages, this has the potential downside that it forbids even
+# of your website's pages, this has the potential downside that it forbids even
 # non-malicious framing of your content (e.g.: when users visit your website
 # using a Google Image Search results page).
 #


### PR DESCRIPTION
I had an issue with Certbot (let's encrypt) which failed to reload nginx due to a non-ASCII character in a loaded config file.
E.g.: `Attempting to renew cert (domain.com) from /etc/letsencrypt/renewal/domain.com.conf produced an unexpected error: 'ascii' codec can't decode byte 0xe2 in position 762: ordinal not in range(128). Skipping.`

I found this character using `grep -r -P '[^\x00-\x7f]' /etc/nginx`.

Looks like only `x-frame-options.conf` is concerned.