### PR TITLE
Update example.com.conf to use error page include

### DIFF
--- a/conf.d/templates/example.com.conf
+++ b/conf.d/templates/example.com.conf
@@ -39,8 +39,8 @@ server {
   # Path for static files
   root /var/www/example.com/public;
 
-  # Custom 404 page
-  error_page 404 /404.html;
+  # Custom error pages
+  include h5bp/errors/custom_errors.conf;
 
   # Include the basic h5bp config set
   include h5bp/basic.conf;


### PR DESCRIPTION
Use the error page include instead of the error_page 404 directive. This aligns example.com.conf with no-ssl.example.com.conf.