### PR TITLE
Update README.md to correct nginx command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Most specific variables are:
 
 * To reload Nginx and apply new config
   ```shell
-  $ nginx reload 
+  $ nginx -s reload 
   ```
 
 
@@ -118,12 +118,12 @@ incorporating the desired functionality from this repository.
 To use directly, replace the Nginx config directory with this repository. for example:
 
 ```shell
-nginx stop
+nginx -s stop
 cd /etc
 mv nginx nginx-previous
 git clone https://github.com/h5bp/server-configs-nginx.git nginx
 # install-specific edits
-nginx start
+nginx
 ```
 
 ### Manage sites
@@ -149,7 +149,7 @@ $ cd /etc/nginx/conf.d
   ```
 
 ```bash
-$ nginx reload
+$ nginx -s reload
 ```
 
 


### PR DESCRIPTION
According to [the official nginx documentation](https://nginx.org/en/docs/beginners_guide.html), commands like `nginx reload` need the `-s` flag, as in `nginx -s reload`.

Also, to start nginx, you do not need a `start` command - simply running the executable without any arguments is sufficient.

This commit fixes the command examples in the README. I've verified that the above is correct on nginx version 1.16.1:

```bash
erik@neutron:~$ sudo nginx start
nginx: invalid option: "start"
erik@neutron:~$ sudo nginx
erik@neutron:~$ sudo nginx reload
nginx: invalid option: "reload"
erik@neutron:~$ sudo nginx -s reload
erik@neutron:~$ sudo nginx stop
nginx: invalid option: "stop"
erik@neutron:~$ sudo nginx -s stop
erik@neutron:~$
```
