### PR TITLE
add fonts to filename-based cache busting

### DIFF
--- a/h5bp/location/web_performance_filename-based_cache_busting.conf
+++ b/h5bp/location/web_performance_filename-based_cache_busting.conf
@@ -9,6 +9,6 @@
 # something like `*.css?v231`, please see:
 # https://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/
 
-location ~* (.+)\.(?:\w+)\.(bmp|css|cur|gif|ico|jpe?g|m?js|png|svgz?|webp|webmanifest)$ {
+location ~* (.+)\.(?:\w+)\.(bmp|css|cur|gif|ico|jpe?g|m?js|png|svgz?|webp|webmanifest|woff?2|eot|ttf|ttc|otf)$ {
   try_files $uri $1.$2;
 }


### PR DESCRIPTION
Fonts files (`.woff2`, `.woff`, `.eot`, `.ttf`, `.ttc` and `.otf`) with filename-based cache busting.