### PR TITLE
Add php expiration for no cache

### DIFF
--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -40,6 +40,9 @@ map $sent_http_content_type $expires {
   # HTML
   ~*text/html                             0;
 
+  # PHP
+  ~*application/x-httpd-php               0;
+
   # JavaScript
   ~*application/javascript                1y;
   ~*application/x-javascript              1y;


### PR DESCRIPTION
Hi,

If PHP is no longer available, the server sends the raw file with Content-Type: application/x-httpd-php and uses the default expiration value of 1 month for this content type.

This causes serious problems because when the PHP pool goes up, the browser continues to serve this raw file.

This is fixed by advising not to cache the application/x-httpd-php type.

(Like h5bp/server-configs-apache#255)