### PR TITLE
docs: Correct reference to weaker policy in doc block.

### DIFF
--- a/h5bp/ssl/policy_intermediate.conf
+++ b/h5bp/ssl/policy_intermediate.conf
@@ -5,9 +5,9 @@
 # For services that don't need backward compatibility, the parameters below
 # provide a higher level of security.
 #
-# (!) This policy enforces a strong SSL configuration, which may raise errors
-#     with old clients.
-#     If a more compatible profile is required, use the intermediate policy.
+# (!) This policy enforces a mildly strong SSL configuration, which may raise
+#     errors with old clients.
+#     If a more compatible profile is required, use the "deprecated" policy.
 #
 # (1) The NIST curves (prime256v1, secp384r1, secp521r1) are known to be weak
 #     and potentially vulnerable but are required to support Microsoft Edge


### PR DESCRIPTION
As discussed in #264 , reference the correct policy `deprecated` in the `h5bp/ssl/policy_intermediate.conf` configuration.