### PR TITLE
Enables the use of JIT for regular expressions to speed-up their proc…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,6 +20,11 @@ worker_processes auto;
 # https://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
 worker_rlimit_nofile 8192;
 
+# Enables the use of JIT for regular expressions to speed-up their processing.
+# Default: off
+# http://nginx.org/en/docs/ngx_core_module.html#pcre_jit
+pcre_jit on;
+
 # Provides the configuration file context in which the directives that affect
 # connection processing are specified.
 # https://nginx.org/en/docs/ngx_core_module.html#events


### PR DESCRIPTION
PCRE JIT can speed up processing of regular expressions significantly and most GNU/Linux distributions have the `with-pcre-jit` compiler flag.