### PR TITLE
Fix GCP CDN caching assets with max-age=0

### DIFF
--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -25,20 +25,20 @@ map $sent_http_content_type $expires {
   ~*application/rdf\+xml                  1h;
   ~*application/rss\+xml                  1h;
 
-  ~*application/json                      -1;
-  ~*application/ld\+json                  -1;
-  ~*application/schema\+json              -1;
-  ~*application/geo\+json                 -1;
-  ~*application/xml                       -1;
-  ~*text/calendar                         -1;
-  ~*text/xml                              -1;
+  ~*application/json                      epoch;
+  ~*application/ld\+json                  epoch;
+  ~*application/schema\+json              epoch;
+  ~*application/geo\+json                 epoch;
+  ~*application/xml                       epoch;
+  ~*text/calendar                         epoch;
+  ~*text/xml                              epoch;
 
   # Favicon (cannot be renamed!) and cursor images
   ~*image/vnd.microsoft.icon              1w;
   ~*image/x-icon                          1w;
 
   # HTML
-  ~*text/html                             -1;
+  ~*text/html                             epoch;
 
   # JavaScript
   ~*application/javascript                1y;
@@ -47,11 +47,11 @@ map $sent_http_content_type $expires {
 
   # Manifest files
   ~*application/manifest\+json            1w;
-  ~*application/x-web-app-manifest\+json  -1;
-  ~*text/cache-manifest                   -1;
+  ~*application/x-web-app-manifest\+json  epoch;
+  ~*text/cache-manifest                   epoch;
 
   # Markdown
-  ~*text/markdown                         -1;
+  ~*text/markdown                         epoch;
 
   # Media files
   ~*audio/                                1y;

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -25,20 +25,20 @@ map $sent_http_content_type $expires {
   ~*application/rdf\+xml                  1h;
   ~*application/rss\+xml                  1h;
 
-  ~*application/json                      0;
-  ~*application/ld\+json                  0;
-  ~*application/schema\+json              0;
-  ~*application/geo\+json                 0;
-  ~*application/xml                       0;
-  ~*text/calendar                         0;
-  ~*text/xml                              0;
+  ~*application/json                      off;
+  ~*application/ld\+json                  off;
+  ~*application/schema\+json              off;
+  ~*application/geo\+json                 off;
+  ~*application/xml                       off;
+  ~*text/calendar                         off;
+  ~*text/xml                              off;
 
   # Favicon (cannot be renamed!) and cursor images
   ~*image/vnd.microsoft.icon              1w;
   ~*image/x-icon                          1w;
 
   # HTML
-  ~*text/html                             0;
+  ~*text/html                             off;
 
   # JavaScript
   ~*application/javascript                1y;
@@ -47,11 +47,11 @@ map $sent_http_content_type $expires {
 
   # Manifest files
   ~*application/manifest\+json            1w;
-  ~*application/x-web-app-manifest\+json  0;
-  ~*text/cache-manifest                   0;
+  ~*application/x-web-app-manifest\+json  off;
+  ~*text/cache-manifest                   off;
 
   # Markdown
-  ~*text/markdown                         0;
+  ~*text/markdown                         off;
 
   # Media files
   ~*audio/                                1y;

--- a/h5bp/web_performance/cache_expiration.conf
+++ b/h5bp/web_performance/cache_expiration.conf
@@ -25,20 +25,20 @@ map $sent_http_content_type $expires {
   ~*application/rdf\+xml                  1h;
   ~*application/rss\+xml                  1h;
 
-  ~*application/json                      off;
-  ~*application/ld\+json                  off;
-  ~*application/schema\+json              off;
-  ~*application/geo\+json                 off;
-  ~*application/xml                       off;
-  ~*text/calendar                         off;
-  ~*text/xml                              off;
+  ~*application/json                      -1;
+  ~*application/ld\+json                  -1;
+  ~*application/schema\+json              -1;
+  ~*application/geo\+json                 -1;
+  ~*application/xml                       -1;
+  ~*text/calendar                         -1;
+  ~*text/xml                              -1;
 
   # Favicon (cannot be renamed!) and cursor images
   ~*image/vnd.microsoft.icon              1w;
   ~*image/x-icon                          1w;
 
   # HTML
-  ~*text/html                             off;
+  ~*text/html                             -1;
 
   # JavaScript
   ~*application/javascript                1y;
@@ -47,11 +47,11 @@ map $sent_http_content_type $expires {
 
   # Manifest files
   ~*application/manifest\+json            1w;
-  ~*application/x-web-app-manifest\+json  off;
-  ~*text/cache-manifest                   off;
+  ~*application/x-web-app-manifest\+json  -1;
+  ~*text/cache-manifest                   -1;
 
   # Markdown
-  ~*text/markdown                         off;
+  ~*text/markdown                         -1;
 
   # Media files
   ~*audio/                                1y;


### PR DESCRIPTION
# Problem

GCP's (Google Cloud Platform) Cloud CDN caches responses with `Cache-Control: max-age=0` and serves it from stale cache. However the application's intent is not to have those responses cached at all.

# Solution

To overcome this, we can remove forcing the `max-age=0` header. This also gives the underlying application the ability to set the `Cache-Control` header itself. The application might have endpoints that should not be cached (`Cache-Control: no-cache, private`) or want to control depending on the response (endpoint?) for how long it should be cached (e.g. `Cache-Control: max-age=60`).