### PR TITLE
Add `browsing-topics` to `Permissions-Policy` header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -145,7 +145,7 @@ http {
   # Add Permissions-Policy for HTML documents.
   # h5bp/security/permissions-policy.conf
   map $sent_http_content_type $permissions_policy {
-    ~*text/(html|javascript)|application/pdf|xml "accelerometer=(),autoplay=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),midi=(),payment=(),picture-in-picture=(),publickey-credentials-get=(),screen-wake-lock=(),sync-xhr=(self),usb=(),web-share=(),xr-spatial-tracking=()";
+    ~*text/(html|javascript)|application/pdf|xml "accelerometer=(),autoplay=(),browsing-topics=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),midi=(),payment=(),picture-in-picture=(),publickey-credentials-get=(),screen-wake-lock=(),sync-xhr=(self),usb=(),web-share=(),xr-spatial-tracking=()";
   }
 
   # Add Referrer-Policy for HTML documents.


### PR DESCRIPTION
Google is currently testing "Topics API," a new proposal for transferring user interests among sites, currently up to about 5% of Google Chrome users ( https://groups.google.com/a/chromium.org/g/blink-dev/c/Vi-Rj37aZLs/m/wzeBWfxxEgAJ )

This may be appropriate for some ad-supported sites, or sites that run landing pages for ads, but can present risks to users in other contexts. Probably safest to set this header to opt out and then let the site administrator change it if they want to use "Topics API" and understand the compliance and security consequences.

There is an existing opt-out for WordPress that does both this and the earlier FLoC system: https://roytanck.com/2021/04/15/opt-out-of-floc-on-your-wordpress-website/